### PR TITLE
theme의 타입 정의 제거

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,6 @@
 import { TColor } from '@/types';
 
-export const theme: { [key: string]: TColor } = {
+export const theme = {
   primary: '#00AD7C',
   primary_dark: '#00936E',
   primary_light: '#52D681',


### PR DESCRIPTION
## ✨ **구현 기능 명세**

theme의 타입 정의를 제거하여, 자동완성이 올바르게 동작하도록 수정하였습니다.

## 🎁 **주목할 점**

### 변경점

```ts
// 변경 전
export const theme: { [key: string]: TColor } = {
  ...
} satisfies { [key: string]: TColor };

// 변경 후
export const theme = {
  ...
} satisfies { [key: string]: TColor };
```

타입 정의를 `satisfies` 키워드만 이용해서 정의하도록 바꾸었습니다.

## 🌄 **스크린샷**

### 변경 전
![image](https://user-images.githubusercontent.com/32933980/232965764-fcb6400d-a6e2-4a7e-944f-1ec586355ef1.png)

### 변경 후
![image](https://user-images.githubusercontent.com/32933980/232965688-ce0abebf-9bca-4a8f-be35-9cbe3e030315.png)
