### PR TITLE
일정생성 모달창의 카테고리 부분 구현

### DIFF
--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,4 @@
+import { ReactComponent as CategoryIconComponent } from '@/assets/category-icon.svg';
 import { ReactComponent as CheckIconComponent } from '@/assets/check-icon.svg';
 import { ReactComponent as CrossIconComponent } from '@/assets/cross-icon.svg';
 import { ReactComponent as GoogleIconComponent } from '@/assets/google-icon.svg';
@@ -19,6 +20,7 @@ const ICON_COMPONENTS = {
   KakaoIcon: KakaoIconComponent,
   MemoIcon: MemoIconComponent,
   TagIcon: TagIconComponent,
+  CategoryIcon: CategoryIconComponent,
 } as const;
 
 export const {
@@ -31,6 +33,7 @@ export const {
   GoogleIcon,
   MemoIcon,
   TagIcon,
+  CategoryIcon,
 } = Object.entries(ICON_COMPONENTS).reduce(
   (result, [key, IconComponent]) => ({
     ...result,

--- a/src/components/modal/plan/Candidates/CandidateItem.tsx
+++ b/src/components/modal/plan/Candidates/CandidateItem.tsx
@@ -33,17 +33,27 @@ const CandidateItem: TCandidateItem = ({
       >
         <CheckIconContainer>
           {isSelected && (
-            <CheckIcon
-              css={{ width: 17, height: 17 }}
-              color={theme.primary_light}
-            />
+            <CheckIcon color={theme.primary_light} width="17" height="17" />
           )}
         </CheckIconContainer>
         <Title>{name}</Title>
       </Container>
     );
   } else {
-    return <div>아직 구현 못함</div>;
+    return (
+      <Container
+        css={isSelected && { backgroundColor: theme.background2 }}
+        {...rest}
+      >
+        <ColorCircle css={{ backgroundColor: color }} />
+        <Title>{name}</Title>
+        <CheckIconContainer>
+          {isSelected && (
+            <CheckIcon color={theme.primary_light} width="17" height="17" />
+          )}
+        </CheckIconContainer>
+      </Container>
+    );
   }
 };
 
@@ -80,6 +90,12 @@ const CheckIconContainer = styled.div`
 const Title = styled.span`
   flex: 1;
   text-align: left;
+`;
+
+const ColorCircle = styled.span`
+  width: 20px;
+  height: 20px;
+  border-radius: 100%;
 `;
 
 export default CandidateItem;

--- a/src/components/modal/plan/Candidates/CandidateItem.tsx
+++ b/src/components/modal/plan/Candidates/CandidateItem.tsx
@@ -25,36 +25,33 @@ const CandidateItem: TCandidateItem = ({
 }: TCandidateItemProps) => {
   const theme = useTheme();
 
-  if (type === 'tag') {
-    return (
-      <Container
-        css={isSelected && { backgroundColor: theme.background2 }}
-        {...rest}
-      >
-        <CheckIconContainer>
-          {isSelected && (
-            <CheckIcon color={theme.primary_light} width="17" height="17" />
-          )}
-        </CheckIconContainer>
-        <Title>{name}</Title>
-      </Container>
-    );
-  } else {
-    return (
-      <Container
-        css={isSelected && { backgroundColor: theme.background2 }}
-        {...rest}
-      >
-        <ColorCircle css={{ backgroundColor: color }} />
-        <Title>{name}</Title>
-        <CheckIconContainer>
-          {isSelected && (
-            <CheckIcon color={theme.primary_light} width="17" height="17" />
-          )}
-        </CheckIconContainer>
-      </Container>
-    );
-  }
+  return (
+    <Container
+      css={isSelected && { backgroundColor: theme.background2 }}
+      {...rest}
+    >
+      {type === 'tag' ? (
+        <>
+          <CheckIconContainer>
+            {isSelected && (
+              <CheckIcon color={theme.primary_light} width="17" height="17" />
+            )}
+          </CheckIconContainer>
+          <Title>{name}</Title>
+        </>
+      ) : (
+        <>
+          <ColorCircle css={{ backgroundColor: color }} />
+          <Title>{name}</Title>
+          <CheckIconContainer>
+            {isSelected && (
+              <CheckIcon color={theme.primary_light} width="17" height="17" />
+            )}
+          </CheckIconContainer>
+        </>
+      )}
+    </Container>
+  );
 };
 
 const Container = styled.button`

--- a/src/components/modal/plan/CategoryCreate.tsx
+++ b/src/components/modal/plan/CategoryCreate.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import { SELECTABLE_COLOR } from '@/constants';
+import { useCategoryCreate } from '@/hooks/rq/category';
+import { FONT_REGULAR_3 } from '@/styles/font';
+import { ICategoryWithoutId } from '@/types/rq/category';
+
+type TCategoryCreateProps = {
+  name: string;
+  onFocus: () => void;
+  onSuccess: (newCategory: ICategoryWithoutId) => void;
+};
+
+type TCategoryCreate = React.FC<TCategoryCreateProps>;
+
+const CategoryCreate: TCategoryCreate = ({
+  name,
+  onFocus,
+  onSuccess,
+}: TCategoryCreateProps) => {
+  const [error, setError] = useState('');
+  const { mutateAsync: createCategory } = useCategoryCreate();
+  const newCategoryName = name.trim();
+
+  const onClick = async () => {
+    try {
+      const newCategory = await createCategory({
+        name: newCategoryName,
+        color: SELECTABLE_COLOR[0],
+      });
+      onSuccess(newCategory);
+    } catch (e) {
+      setError('카테고리 생성에 실패했습니다.');
+      // todo: 토스트 메시지 띄워주기
+    }
+  };
+
+  return (
+    <Container onFocus={onFocus}>
+      <span>"{newCategoryName}"</span>
+      <Button onMouseDown={onClick}>카테고리 생성하기</Button>
+      <Warning>{error}</Warning>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin: 20px 0;
+  width: 100%;
+  text-align: center;
+  color: ${({ theme }) => theme.placeholder};
+  ${FONT_REGULAR_3}
+`;
+
+const Button = styled.button`
+  color: inherit;
+  font: inherit;
+  width: fit-content;
+
+  &:hover {
+    color: ${({ theme }) => theme.primary};
+  }
+`;
+
+const Warning = styled.span`
+  color: ${({ theme }) => theme.red};
+`;
+
+export default CategoryCreate;

--- a/src/components/modal/plan/CategoryCreate.tsx
+++ b/src/components/modal/plan/CategoryCreate.tsx
@@ -9,7 +9,6 @@ import { ICategoryWithoutId } from '@/types/rq/category';
 
 type TCategoryCreateProps = {
   name: string;
-  onFocus: () => void;
   onSuccess: (newCategory: ICategoryWithoutId) => void;
 };
 
@@ -17,7 +16,6 @@ type TCategoryCreate = React.FC<TCategoryCreateProps>;
 
 const CategoryCreate: TCategoryCreate = ({
   name,
-  onFocus,
   onSuccess,
 }: TCategoryCreateProps) => {
   const [error, setError] = useState('');
@@ -38,7 +36,7 @@ const CategoryCreate: TCategoryCreate = ({
   };
 
   return (
-    <Container onFocus={onFocus}>
+    <Container>
       <span>"{newCategoryName}"</span>
       <Button onMouseDown={onClick}>카테고리 생성하기</Button>
       <Warning>{error}</Warning>

--- a/src/components/modal/plan/CategoryCreate.tsx
+++ b/src/components/modal/plan/CategoryCreate.tsx
@@ -22,7 +22,7 @@ const CategoryCreate: TCategoryCreate = ({
   const { mutateAsync: createCategory } = useCategoryCreate();
   const newCategoryName = name.trim();
 
-  const onClick = async () => {
+  const onMouseDown = async () => {
     try {
       const newCategory = await createCategory({
         name: newCategoryName,
@@ -38,7 +38,7 @@ const CategoryCreate: TCategoryCreate = ({
   return (
     <Container>
       <span>"{newCategoryName}"</span>
-      <Button onMouseDown={onClick}>카테고리 생성하기</Button>
+      <Button onMouseDown={onMouseDown}>카테고리 생성하기</Button>
       <Warning>{error}</Warning>
     </Container>
   );

--- a/src/components/modal/plan/CategoryCreateForm.tsx
+++ b/src/components/modal/plan/CategoryCreateForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -14,16 +14,19 @@ type TCategoryCreateProps = {
 
 type TCategoryCreate = React.FC<TCategoryCreateProps>;
 
-const CategoryCreate: TCategoryCreate = ({
+const CategoryCreateForm: TCategoryCreate = ({
   name,
   onSuccess,
 }: TCategoryCreateProps) => {
   const [error, setError] = useState('');
+  const loadingRef = useRef(false);
   const { mutateAsync: createCategory } = useCategoryCreate();
   const newCategoryName = name.trim();
 
   const onMouseDown = async () => {
+    if (loadingRef.current) return;
     try {
+      loadingRef.current = true;
       const newCategory = await createCategory({
         name: newCategoryName,
         color: SELECTABLE_COLOR[0],
@@ -32,6 +35,8 @@ const CategoryCreate: TCategoryCreate = ({
     } catch (e) {
       setError('카테고리 생성에 실패했습니다.');
       // todo: 토스트 메시지 띄워주기
+    } finally {
+      loadingRef.current = false;
     }
   };
 
@@ -71,4 +76,4 @@ const Warning = styled.span`
   color: ${({ theme }) => theme.red};
 `;
 
-export default CategoryCreate;
+export default CategoryCreateForm;

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -61,12 +61,12 @@ const PlanCategory: React.FC = () => {
   };
 
   const onInput = (e: ChangeEvent<HTMLInputElement>) => {
-    const input = e.target.value.trim();
+    const input = e.target.value;
     setCategoryInput(input);
     if (input === '') {
       onClear();
     } else {
-      filterCategories(input);
+      filterCategories(input.trim());
     }
   };
 
@@ -92,7 +92,7 @@ const PlanCategory: React.FC = () => {
           {filteredCategories.map((category) => (
             <Candidate.Item
               key={`Candidate-${category.name}`}
-              isSelected={category.id === selectedCategory?.id}
+              isSelected={category.name === selectedCategory?.name}
               name={category.name}
               color={category.color}
               onMouseDown={() => onSelectCategory(category)}

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -81,7 +81,7 @@ const PlanCategory: React.FC = () => {
         value={categoryInput}
         // onFocus에 filterCategoriesCb인 이유는 debounce 없이 바로 적용되기 위함
         onFocus={() => filterCategoriesCb(inputRef.current?.value.trim() || '')}
-        onBlur={() => filteredType !== 'noMatch' && setFilteredType(null)}
+        onBlur={() => setFilteredType(null)}
         placeholder={'카테고리를 입력하세요'}
         onClear={onClear}
         onChange={onInput}

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -1,0 +1,114 @@
+import React, { ChangeEvent, useRef, useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import Dropdown from '@/components/common/dropdown';
+import Input from '@/components/common/Input';
+import { CategoryIcon } from '@/components/icons';
+import { Candidate } from '@/components/modal/plan/Candidates';
+import CategoryCreate from '@/components/modal/plan/CategoryCreate';
+import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
+import { MAX_CANDIDATE_LENGTH } from '@/constants';
+import { useCategoryQuery } from '@/hooks/rq/category';
+import useDebounce from '@/hooks/useDebounce';
+import { ICategory, ICategoryWithoutId } from '@/types/rq/category';
+
+// 입력과 일치하는 category 존재여부에 따라 다른 것을 보여주기 위해 정의한 타입
+// 입력과 일치하는 category가 있을 경우: candidate
+// 일치하는 category가 없을 경우: noMatch
+type TFilteredType = 'candidate' | 'noMatch';
+
+const PlanCategory: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { data: categoryData } = useCategoryQuery();
+  const [filteredCategories, setFilteredCategories] = useState<ICategory[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<
+    (ICategoryWithoutId & { id?: number }) | null
+  >(null);
+  const [categoryInput, setCategoryInput] = useState('');
+  const [filteredType, setFilteredType] = useState<TFilteredType | null>(null);
+
+  const onSelectCategory = (category: ICategoryWithoutId) => {
+    setSelectedCategory(category);
+    setFilteredCategories([]);
+    setFilteredType(null);
+    setCategoryInput('');
+  };
+
+  const filterCategoriesCb = (categoryName: string) => {
+    if (categoryName === '') return;
+
+    const filtered = (categoryData ?? [])
+      .filter((category) => category.name.match(categoryName))
+      .slice(0, MAX_CANDIDATE_LENGTH); // 최대 4개까지 보이도록
+
+    if (filtered.length > 0) {
+      setFilteredCategories(filtered);
+      setFilteredType('candidate');
+    } else {
+      setFilteredCategories([]);
+      setFilteredType('noMatch');
+    }
+  };
+
+  // Debounce를 활용해서 카테고리 이름 입력시 카테고리 후보 필터링
+  const filterCategories = useDebounce(filterCategoriesCb, 300);
+
+  const onClear = () => {
+    setFilteredCategories([]);
+    setFilteredType(null);
+    setCategoryInput('');
+  };
+
+  const onInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value.trim();
+    setCategoryInput(input);
+    if (input === '') {
+      onClear();
+    } else {
+      filterCategories(input);
+    }
+  };
+
+  return (
+    <Container>
+      <Dropdown.Controller>
+        <ClassifierTitle title="카테고리" titleIcon={<CategoryIcon />} />
+      </Dropdown.Controller>
+      <Input
+        type="text"
+        ref={inputRef}
+        value={categoryInput}
+        // onFocus에 filterCategoriesCb인 이유는 debounce 없이 바로 적용되기 위함
+        onFocus={() => filterCategoriesCb(inputRef.current?.value.trim() || '')}
+        onBlur={() => filteredType !== 'noMatch' && setFilteredType(null)}
+        placeholder={'카테고리를 입력하세요'}
+        onClear={onClear}
+        onChange={onInput}
+        maxLength={20}
+      />
+      {filteredType === 'candidate' && (
+        <Candidate.List type="category">
+          {filteredCategories.map((category) => (
+            <Candidate.Item
+              key={`Candidate-${category.name}`}
+              isSelected={category.id === selectedCategory?.id}
+              name={category.name}
+              color={category.color}
+              onMouseDown={() => onSelectCategory(category)}
+            />
+          ))}
+        </Candidate.List>
+      )}
+      {filteredType === 'noMatch' && categoryInput && (
+        <CategoryCreate name={categoryInput} onSuccess={onSelectCategory} />
+      )}
+    </Container>
+  );
+};
+
+const Container = styled(Dropdown)`
+  width: 100%;
+  position: relative;
+`;
+export default PlanCategory;

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -6,7 +6,7 @@ import Dropdown from '@/components/common/dropdown';
 import Input from '@/components/common/Input';
 import { CategoryIcon } from '@/components/icons';
 import { Candidate } from '@/components/modal/plan/Candidates';
-import CategoryCreate from '@/components/modal/plan/CategoryCreate';
+import CategoryCreateForm from '@/components/modal/plan/CategoryCreateForm';
 import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
 import { MAX_CANDIDATE_LENGTH } from '@/constants';
 import { useCategoryQuery } from '@/hooks/rq/category';
@@ -42,13 +42,8 @@ const PlanCategory: React.FC = () => {
       .filter((category) => category.name.match(categoryName))
       .slice(0, MAX_CANDIDATE_LENGTH); // 최대 4개까지 보이도록
 
-    if (filtered.length > 0) {
-      setFilteredCategories(filtered);
-      setFilteredType('candidate');
-    } else {
-      setFilteredCategories([]);
-      setFilteredType('noMatch');
-    }
+    setFilteredCategories(filtered);
+    setFilteredType(filtered.length > 0 ? 'candidate' : 'noMatch');
   };
 
   // Debounce를 활용해서 카테고리 이름 입력시 카테고리 후보 필터링
@@ -101,7 +96,7 @@ const PlanCategory: React.FC = () => {
         </Candidate.List>
       )}
       {filteredType === 'noMatch' && categoryInput && (
-        <CategoryCreate name={categoryInput} onSuccess={onSelectCategory} />
+        <CategoryCreateForm name={categoryInput} onSuccess={onSelectCategory} />
       )}
     </Container>
   );

--- a/src/hooks/rq/category.ts
+++ b/src/hooks/rq/category.ts
@@ -41,7 +41,7 @@ const useCategoryCreate = () => {
   return useMutation(
     // api 호출
     (newCategory: ICategoryWithoutId) => {
-      return new Promise((resolve) => {
+      return new Promise<ICategoryWithoutId>((resolve) => {
         setTimeout(() => {
           resolve(newCategory);
         }, 100);

--- a/src/stories/plan/PlanCategory.stories.tsx
+++ b/src/stories/plan/PlanCategory.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PlanCategory from '@/components/modal/plan/PlanCategory';
+
+export default {
+  title: 'Plan/PlanCategory',
+  component: PlanCategory,
+} as ComponentMeta<typeof PlanCategory>;
+
+const Template: ComponentStory<typeof PlanCategory> = (args) => {
+  return <PlanCategory {...args} />;
+};
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/src/utils/mock.ts
+++ b/src/utils/mock.ts
@@ -1,9 +1,14 @@
+import { SELECTABLE_COLOR } from '@/constants';
 import { ICategory } from '@/types/rq/category';
 import { IPlan } from '@/types/rq/plan';
 import { ITag } from '@/types/rq/tag';
 
 const CATEGORY_MOCK: ICategory[] = [
-  { id: 1, name: '테스트1', color: '#52d681' },
+  { id: 1, name: '카테고리1', color: SELECTABLE_COLOR[0] },
+  { id: 2, name: '카테고리2', color: SELECTABLE_COLOR[1] },
+  { id: 3, name: '카테고리3', color: SELECTABLE_COLOR[2] },
+  { id: 4, name: '카테고리4', color: SELECTABLE_COLOR[3] },
+  { id: 5, name: '카테고리5', color: SELECTABLE_COLOR[4] },
 ];
 
 const TAG_MOCK: ITag[] = [


### PR DESCRIPTION
## ✨ **구현 기능 명세**

일정생성 모달창의 카테고리 부분을 구현하였습니다. 이 컴포넌트에서 카테고리를 선택할 수도 있으며 새롭게 생성할 수도 있습니다.

**하지만 아직 선택된 카테고리를 보여주지는 않습니다.** 왜냐하면 Figma 상으로는 `ClassifierTitle`에 이것을 보여주어야하는데, 이 PR에 그것까지 구현하게 되면 단위가 커질 수 있을 것 같았습니다. 그래서 해당 기능은 이 PR 이후에 구현할 예정입니다.

## 🎁 **주목할 점**

### React Query와의 연동

기존 Category 생성/수정 모달창을 위해 React Query를 임시구현했었습니다. 그 코드를 이용하여 이 컴포넌트는 React Query와의 연동이 됩니다.

```tsx
const PlanCategory: React.FC = () => {
  const { data: categoryData } = useCategoryQuery();
  ...
}

const CategoryCreate: TCategoryCreate = ({
  name,
  onSuccess,
}: TCategoryCreateProps) => {
  const { mutateAsync: createCategory } = useCategoryCreate();
  ...
}
```

## 😭 **어려웠던 점**

### filteredType

`PlanCategory` 컴포넌트를 보면 `filteredType`이라는 상태가 있습니다. 이 상태는
![image](https://user-images.githubusercontent.com/32933980/234213164-50d84448-d4ef-45e8-8e3a-182b9a9a14cf.png)
![image](https://user-images.githubusercontent.com/32933980/234213234-ed882082-8e11-448b-a3fe-d37ed2873280.png)

위 두 경우 중 어떤 것을 보여주어야하는지를 나타낸 상태입니다. (만약 null 이라면 아무것도 보여주지 않는 상태입니다.)

이 상태의 이름이 직관적이지 않은 것 같습니다. 이름을 어떻게 바꾸는 것이 좋을까요??

## 🌄 **스크린샷**

![category](https://user-images.githubusercontent.com/32933980/234212720-d752eb6d-802a-4203-b3d2-957629b21ccd.gif)
