### PR TITLE
Storybook에서 Calendar 동작이 잘 안먹히던 버그 수정

### DIFF
--- a/src/stores/date/calendarUnit.ts
+++ b/src/stores/date/calendarUnit.ts
@@ -12,7 +12,7 @@ interface ICalendarUnitAction {
 }
 
 const initialState = {
-  selectedCalendarUnit: CALENDAR_UNIT[1],
+  selectedCalendarUnit: CALENDAR_UNIT[2],
 } as const;
 
 const useCalendarUnitState = create<ICalendarUnitState & ICalendarUnitAction>(

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -1,16 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CalendarView from '@/components/calendars/large';
 import CalendarHeader from '@/components/common/calendar/CalendarHeader';
+import { CALENDAR_UNIT } from '@/constants';
+import useCalendarUnitState from '@/stores/date/calendarUnit';
 
 export default {
   title: 'calendars/LargeCalendar',
   component: CalendarView,
 } as ComponentMeta<typeof CalendarView>;
 
-const Template: ComponentStory<typeof CalendarView> = () => <CalendarView />;
+const Template: ComponentStory<typeof CalendarView> = () => {
+  const { selectCalendarUnit } = useCalendarUnitState();
+  useEffect(() => {
+    selectCalendarUnit(CALENDAR_UNIT[2]);
+  }, []);
+
+  return <CalendarView />;
+};
 const Template2 = () => <CalendarHeader />;
 
 export const View = Template.bind({});

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CalendarView from '@/components/calendars/large';
@@ -13,37 +12,9 @@ export default {
 
 const Template: ComponentStory<typeof CalendarView> = () => <CalendarView />;
 const Template2 = () => <CalendarHeader />;
-const Template3 = () => {
-  return (
-    <Container>
-      <CalendarHeader />
-      <section>
-        <CalendarView />
-      </section>
-    </Container>
-  );
-};
-
-const Container = styled.div`
-  display: flex;
-
-  height: 100%;
-
-  flex-direction: column;
-
-  & > section {
-    background-color: ${({ theme }) => theme.primary_light3};
-    flex: 1;
-    display: flex;
-    padding: 1rem;
-  }
-`;
 
 export const View = Template.bind({});
 View.args = {};
 
 export const Header = Template2.bind({});
 Template2.args = {};
-
-export const Main = Template3.bind({});
-Template3.args = {};

--- a/src/stories/calendars/SmallCalendar.stories.tsx
+++ b/src/stories/calendars/SmallCalendar.stories.tsx
@@ -1,24 +1,48 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Calendar from '@/components/calendars/small/index';
+import { CALENDAR_UNIT } from '@/constants';
+import useCalendarUnitState from '@/stores/date/calendarUnit';
 
 export default {
   title: 'calendars/SmallCalendar',
   component: Calendar,
+  argTypes: {
+    selectedCalendarIndex: {
+      options: [0, 1, 2],
+      control: {
+        type: 'select',
+        labels: CALENDAR_UNIT,
+      },
+    },
+  },
 } as ComponentMeta<typeof Calendar>;
 
 const Container = styled.div`
   width: 300px;
 `;
 
-const Template: ComponentStory<typeof Calendar> = () => (
-  <Container>
-    <Calendar />
-  </Container>
-);
+const Template: ComponentStory<
+  React.FC<{
+    selectedCalendarIndex: 0 | 1 | 2;
+  }>
+> = ({ selectedCalendarIndex }) => {
+  const { selectCalendarUnit } = useCalendarUnitState();
+  useEffect(() => {
+    selectCalendarUnit(CALENDAR_UNIT[selectedCalendarIndex]);
+  }, [selectedCalendarIndex]);
+
+  return (
+    <Container>
+      <Calendar />
+    </Container>
+  );
+};
 
 export const Primary = Template.bind({});
-Primary.args = {};
+Primary.args = {
+  selectedCalendarIndex: 2,
+};


### PR DESCRIPTION
* Closes #47

### 해당 PR은 #41 에 합쳐집니다. (리뷰를 위한 파일 분리)

## ✨ **구현 기능 명세**

* Storybook에서 해당 달력을 렌더링 할 때 전역 상태를 변경하기
* Storybook의 small calendar에서 `selectedCalendarUnit`을 변경할 수 있도록 수정
* 기초 `selectedCalendarUnit`의 데이터 값을 `'월'`로 사용할 수 있도록 변경

## 🎁 **주목할 점**

Storybook의 `Template` 컴포넌트에서 해당 작업들을 진행하여 렌더링할 수 있도록 설정했습니다.

## 🌄 **스크린샷**

![화면 기록 2023-04-28 오후 1 38 30](https://user-images.githubusercontent.com/55688122/235055508-6e5f4b1a-30be-4cdc-809f-2f5af241ac14.gif)
