### PR TITLE
일정생성 모달 UI 구현

### DIFF
--- a/src/components/buttons/Checkbox.tsx
+++ b/src/components/buttons/Checkbox.tsx
@@ -3,7 +3,10 @@ import React, { InputHTMLAttributes } from 'react';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { FONT_BOLD_3 } from '@/styles/font';
+
 type TCheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
+  className?: string;
   label?: string;
   checked: boolean;
   id?: string;
@@ -12,13 +15,14 @@ type TCheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
 type TCheckbox = React.FC<TCheckboxProps>;
 
 const Checkbox: TCheckbox = ({
+  className,
   label,
   checked,
   id = 'all_day_checkbox',
   ...rest
 }: TCheckboxProps) => {
   return (
-    <Container>
+    <Container className={className}>
       <CheckboxInput type="checkbox" id={id} checked={checked} {...rest} />
       <Label htmlFor={id}>
         <CheckboxSquare />
@@ -30,6 +34,7 @@ const Checkbox: TCheckbox = ({
 
 const Container = styled.div`
   display: flex;
+  width: fit-content;
 `;
 
 const checkboxCheck = keyframes`
@@ -67,6 +72,7 @@ const shrinkBounce = keyframes`
 const CheckboxInput = styled.input`
   width: 0;
   height: 0;
+  margin: 0;
 
   &:checked + label > span {
     border: 0.5em solid ${({ theme }) => theme.primary};
@@ -93,8 +99,9 @@ const Label = styled.label`
   column-gap: 8px;
   align-items: center;
   cursor: pointer;
-  color: ${({ theme }) => theme.text1};
+  color: ${({ theme }) => theme.black};
   transition: color 250ms cubic-bezier(0.4, 0, 0.23, 1);
+  ${FONT_BOLD_3}
 `;
 
 const CheckboxSquare = styled.span`

--- a/src/components/modal/plan/DateDisplay.tsx
+++ b/src/components/modal/plan/DateDisplay.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+// todo: store의 상태와 연동하여 날짜 보여주기, 현재는 임시 구현
+const DateDisplay: React.FC = () => {
+  return <Container>일정 기간 표시</Container>;
+};
+
+const Container = styled.div`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  width: 100%;
+  height: 48px;
+`;
+
+export default DateDisplay;

--- a/src/components/modal/plan/PlanAllDay.tsx
+++ b/src/components/modal/plan/PlanAllDay.tsx
@@ -12,7 +12,7 @@ const PlanAllDay = () => {
       <Checkbox
         label="종일"
         checked={isAllDay}
-        onClick={() => setIsAllDay((prev) => !prev)}
+        onChange={() => setIsAllDay((prev) => !prev)}
       />
     </Container>
   );
@@ -20,6 +20,7 @@ const PlanAllDay = () => {
 
 const Container = styled.div`
   width: 100%;
+  padding: 10px 0;
 `;
 
 export default PlanAllDay;

--- a/src/components/modal/plan/PlanAllDay.tsx
+++ b/src/components/modal/plan/PlanAllDay.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import Checkbox from '@/components/buttons/Checkbox';
+
+const PlanAllDay = () => {
+  const [isAllDay, setIsAllDay] = useState(false);
+
+  return (
+    <Container>
+      <Checkbox
+        label="종일"
+        checked={isAllDay}
+        onClick={() => setIsAllDay((prev) => !prev)}
+      />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 100%;
+`;
+
+export default PlanAllDay;

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -71,7 +71,7 @@ const PlanCategory: React.FC = () => {
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="카테고리"
-          titleIcon={<CategoryIcon />}
+          titleIcon={<CategoryIcon width="18" height="18" />}
           additionalComponent={
             selectedCategory && (
               <SelectedCategoryDisplay

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -8,10 +8,10 @@ import { CategoryIcon } from '@/components/icons';
 import { Candidate } from '@/components/modal/plan/Candidates';
 import CategoryCreateForm from '@/components/modal/plan/category/CategoryCreateForm';
 import SelectedCategoryDisplay from '@/components/modal/plan/category/SelectedCategoryDisplay';
-import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
 import { MAX_CANDIDATE_LENGTH } from '@/constants';
 import { useCategoryQuery } from '@/hooks/rq/category';
 import useDebounce from '@/hooks/useDebounce';
+import { PlanModalClassifierTitle } from '@/styles/planModal';
 import { ICategory, ICategoryWithoutId } from '@/types/rq/category';
 
 // 입력과 일치하는 category 존재여부에 따라 다른 것을 보여주기 위해 정의한 타입
@@ -69,7 +69,7 @@ const PlanCategory: React.FC = () => {
   return (
     <Container>
       <Dropdown.Controller>
-        <ClassifierTitle
+        <PlanModalClassifierTitle
           title="카테고리"
           titleIcon={<CategoryIcon />}
           additionalComponent={

--- a/src/components/modal/plan/PlanMemo.tsx
+++ b/src/components/modal/plan/PlanMemo.tsx
@@ -11,6 +11,11 @@ import { MemoIcon } from '@/components/icons';
 import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
 import { MAX_MEMO_LENGTH } from '@/constants';
 import { FONT_REGULAR_4 } from '@/styles/font';
+import {
+  ClassifierAdditionalFontStyle,
+  ClassifierAdditionalMarginRight,
+  PlanModalClassifierTitle,
+} from '@/styles/planModal';
 
 type TPlanMemoProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
@@ -36,7 +41,7 @@ const PlanMemo: TPlanMemo = ({ onChange, ...rest }: TPlanMemoProps) => {
   return (
     <Container duration={0.5}>
       <Dropdown.Controller>
-        <ClassifierTitle
+        <PlanModalClassifierTitle
           title="메모"
           titleIcon={<MemoIcon />}
           additionalComponent={
@@ -79,8 +84,9 @@ const TextArea = styled.textarea`
 `;
 
 const ContentLenDisplay = styled.span`
-  margin-right: 15px;
+  margin-right: ${ClassifierAdditionalMarginRight};
   color: ${({ theme }) => theme.text3};
+  ${ClassifierAdditionalFontStyle}
 `;
 
 export default PlanMemo;

--- a/src/components/modal/plan/PlanMemo.tsx
+++ b/src/components/modal/plan/PlanMemo.tsx
@@ -1,14 +1,9 @@
-import React, {
-  ChangeEventHandler,
-  TextareaHTMLAttributes,
-  useRef,
-} from 'react';
+import React, { ChangeEventHandler, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import Dropdown from '@/components/common/dropdown';
 import { MemoIcon } from '@/components/icons';
-import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
 import { MAX_MEMO_LENGTH } from '@/constants';
 import { FONT_REGULAR_4 } from '@/styles/font';
 import {
@@ -17,12 +12,9 @@ import {
   PlanModalClassifierTitle,
 } from '@/styles/planModal';
 
-type TPlanMemoProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
-
-type TPlanMemo = React.FC<TPlanMemoProps>;
-
-const PlanMemo: TPlanMemo = ({ onChange, ...rest }: TPlanMemoProps) => {
+const PlanMemo: React.FC = () => {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const [memo, setMemo] = useState('');
 
   const handleTextareaHeight = () => {
     const current = ref.current;
@@ -34,7 +26,7 @@ const PlanMemo: TPlanMemo = ({ onChange, ...rest }: TPlanMemoProps) => {
   const onChangeTextArea: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
     handleTextareaHeight();
     if (e.target.value.length <= MAX_MEMO_LENGTH) {
-      onChange?.(e);
+      setMemo(e.target.value);
     }
   };
 
@@ -43,10 +35,10 @@ const PlanMemo: TPlanMemo = ({ onChange, ...rest }: TPlanMemoProps) => {
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="메모"
-          titleIcon={<MemoIcon />}
+          titleIcon={<MemoIcon width="18" height="18" />}
           additionalComponent={
             <ContentLenDisplay>
-              {ref.current?.value.length ?? 0} / {MAX_MEMO_LENGTH}
+              {memo.length} / {MAX_MEMO_LENGTH}
             </ContentLenDisplay>
           }
         />
@@ -55,8 +47,8 @@ const PlanMemo: TPlanMemo = ({ onChange, ...rest }: TPlanMemoProps) => {
         <TextArea
           placeholder={`메모를 최대 ${MAX_MEMO_LENGTH}자까지 입력할 수 있습니다`}
           ref={ref}
+          value={memo}
           onChange={onChangeTextArea}
-          {...rest}
         />
       </div>
     </Container>
@@ -76,6 +68,7 @@ const TextArea = styled.textarea`
   font-family: inherit;
   line-height: 1.5;
   padding: 0 24px 0;
+  height: 18px;
   ${FONT_REGULAR_4}
 
   &::placeholder {

--- a/src/components/modal/plan/PlanMemo.tsx
+++ b/src/components/modal/plan/PlanMemo.tsx
@@ -14,7 +14,7 @@ import {
 
 const PlanMemo: React.FC = () => {
   const ref = useRef<HTMLTextAreaElement>(null);
-  const [memo, setMemo] = useState('');
+  const [description, setDescription] = useState('');
 
   const handleTextareaHeight = () => {
     const current = ref.current;
@@ -26,7 +26,7 @@ const PlanMemo: React.FC = () => {
   const onChangeTextArea: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
     handleTextareaHeight();
     if (e.target.value.length <= MAX_MEMO_LENGTH) {
-      setMemo(e.target.value);
+      setDescription(e.target.value);
     }
   };
 
@@ -38,7 +38,7 @@ const PlanMemo: React.FC = () => {
           titleIcon={<MemoIcon width="18" height="18" />}
           additionalComponent={
             <ContentLenDisplay>
-              {memo.length} / {MAX_MEMO_LENGTH}
+              {description.length} / {MAX_MEMO_LENGTH}
             </ContentLenDisplay>
           }
         />
@@ -47,7 +47,7 @@ const PlanMemo: React.FC = () => {
         <TextArea
           placeholder={`메모를 최대 ${MAX_MEMO_LENGTH}자까지 입력할 수 있습니다`}
           ref={ref}
-          value={memo}
+          value={description}
           onChange={onChangeTextArea}
         />
       </div>

--- a/src/components/modal/plan/PlanTag.tsx
+++ b/src/components/modal/plan/PlanTag.tsx
@@ -74,7 +74,7 @@ const PlanTag: React.FC = () => {
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="태그"
-          titleIcon={<TagIcon />}
+          titleIcon={<TagIcon width="18" height="18" />}
           additionalComponent={
             <SelectedTagUnit>
               {selectedTags.length} / {MAX_TAG_LENGTH}

--- a/src/components/modal/plan/PlanTag.tsx
+++ b/src/components/modal/plan/PlanTag.tsx
@@ -6,9 +6,13 @@ import TagButton from '@/components/buttons/TagButton';
 import Dropdown from '@/components/common/dropdown';
 import Input from '@/components/common/Input';
 import { TagIcon } from '@/components/icons';
-import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
 import { MAX_CANDIDATE_LENGTH, MAX_TAG_LENGTH } from '@/constants';
 import useDebounce from '@/hooks/useDebounce';
+import {
+  ClassifierAdditionalFontStyle,
+  ClassifierAdditionalMarginRight,
+  PlanModalClassifierTitle,
+} from '@/styles/planModal';
 import { TAG_MOCK } from '@/utils/mock';
 import { Candidate } from 'components/modal/plan/Candidates';
 
@@ -68,7 +72,7 @@ const PlanTag: React.FC = () => {
   return (
     <Container>
       <Dropdown.Controller>
-        <ClassifierTitle
+        <PlanModalClassifierTitle
           title="태그"
           titleIcon={<TagIcon />}
           additionalComponent={
@@ -135,8 +139,9 @@ const TagButtonContainer = styled.div`
 `;
 
 const SelectedTagUnit = styled.span`
-  margin-right: 15px;
+  margin-right: ${ClassifierAdditionalMarginRight};
   color: ${({ theme }) => theme.text3};
+  ${ClassifierAdditionalFontStyle}
 `;
 
 export default PlanTag;

--- a/src/components/modal/plan/category/CategoryCreateForm.tsx
+++ b/src/components/modal/plan/category/CategoryCreateForm.tsx
@@ -55,7 +55,7 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
-  margin: 20px 0;
+  margin: 20px 0 10px;
   width: 100%;
   text-align: center;
   color: ${({ theme }) => theme.placeholder};

--- a/src/components/modal/plan/index.tsx
+++ b/src/components/modal/plan/index.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import ModalContainer from '..';
+
+import StylishButton from '@/components/buttons/StylishButton';
+import ColorPicker from '@/components/common/ColorPicker';
+import Input from '@/components/common/Input';
+import ChevronIcon from '@/components/icons/ChevronIcon';
+import PlanAllDay from '@/components/modal/plan/PlanAllDay';
+import PlanCategory from '@/components/modal/plan/PlanCategory';
+import PlanMemo from '@/components/modal/plan/PlanMemo';
+import PlanTag from '@/components/modal/plan/PlanTag';
+import { SELECTABLE_COLOR } from '@/constants';
+import { useCategoryQuery } from '@/hooks/rq/category';
+import { FONT_BOLD_1 } from '@/styles/font';
+import { TColor } from '@/types';
+
+type TPlanModalProps = {
+  onClose: () => void;
+  onDone: (obj: any) => void;
+};
+
+type TPlanModal = React.FC<TPlanModalProps>;
+
+const PlanModal: TPlanModal = ({ onClose, onDone }: TPlanModalProps) => {
+  const { data: categoryData } = useCategoryQuery();
+  const [selectedColor, setSelectedColor] = useState<TColor>(
+    SELECTABLE_COLOR[0],
+  );
+  const [planName, setPlanName] = useState('');
+
+  const onSubmit = () => {
+    console.log('클릭');
+  };
+
+  return (
+    <Modal
+      onClose={onClose}
+      isBgBlack={true}
+      HeaderLeftComponent={
+        <ColorPicker
+          selectedColor={selectedColor}
+          onSelect={(color: TColor) => setSelectedColor(color)}
+          additionalComponent={
+            <ChevronIcon width="14" type="down" color="black" />
+          }
+        />
+      }
+    >
+      <PlanInput
+        type="text"
+        isInline={true}
+        placeholder="일정 제목"
+        value={planName}
+        onChange={(e) => setPlanName(e.target.value)}
+      />
+      <PlanAllDay />
+      <PlanMemo />
+      <Hr />
+      <PlanCategory />
+      <Hr />
+      <PlanTag />
+      <StylishButton
+        isColor={true}
+        size="large"
+        onClick={onSubmit}
+        css={{ marginTop: 20 }}
+        // disabled={!newCategoryName}
+      >
+        생성
+      </StylishButton>
+    </Modal>
+  );
+};
+
+const Modal = styled(ModalContainer)`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400px;
+  padding: 24px;
+  box-shadow: 1px 10px 25px rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+`;
+
+const PlanInput = styled(Input)`
+  padding: 15px 0;
+  ${FONT_BOLD_1};
+`;
+
+const Hr = styled.hr`
+  width: 100%;
+  height: 1px;
+  border: none;
+  background-color: ${({ theme }) => theme.background3};
+`;
+export default PlanModal;

--- a/src/components/modal/plan/index.tsx
+++ b/src/components/modal/plan/index.tsx
@@ -8,31 +8,36 @@ import StylishButton from '@/components/buttons/StylishButton';
 import ColorPicker from '@/components/common/ColorPicker';
 import Input from '@/components/common/Input';
 import ChevronIcon from '@/components/icons/ChevronIcon';
+import DateDisplay from '@/components/modal/plan/DateDisplay';
 import PlanAllDay from '@/components/modal/plan/PlanAllDay';
 import PlanCategory from '@/components/modal/plan/PlanCategory';
 import PlanMemo from '@/components/modal/plan/PlanMemo';
 import PlanTag from '@/components/modal/plan/PlanTag';
 import { SELECTABLE_COLOR } from '@/constants';
-import { useCategoryQuery } from '@/hooks/rq/category';
 import { FONT_BOLD_1 } from '@/styles/font';
 import { TColor } from '@/types';
 
 type TPlanModalProps = {
+  isEdit?: boolean;
   onClose: () => void;
   onDone: (obj: any) => void;
 };
 
 type TPlanModal = React.FC<TPlanModalProps>;
 
-const PlanModal: TPlanModal = ({ onClose, onDone }: TPlanModalProps) => {
-  const { data: categoryData } = useCategoryQuery();
+const PlanModal: TPlanModal = ({
+  isEdit = false,
+  onClose,
+  onDone,
+}: TPlanModalProps) => {
   const [selectedColor, setSelectedColor] = useState<TColor>(
     SELECTABLE_COLOR[0],
   );
   const [planName, setPlanName] = useState('');
 
   const onSubmit = () => {
-    console.log('클릭');
+    onDone(planName);
+    // todo: 일정생성 api 호출 및 onDone에 일정 데이터 넣어서 호출
   };
 
   return (
@@ -56,7 +61,9 @@ const PlanModal: TPlanModal = ({ onClose, onDone }: TPlanModalProps) => {
         value={planName}
         onChange={(e) => setPlanName(e.target.value)}
       />
+      <DateDisplay />
       <PlanAllDay />
+      <Hr />
       <PlanMemo />
       <Hr />
       <PlanCategory />
@@ -67,9 +74,9 @@ const PlanModal: TPlanModal = ({ onClose, onDone }: TPlanModalProps) => {
         size="large"
         onClick={onSubmit}
         css={{ marginTop: 20 }}
-        // disabled={!newCategoryName}
+        disabled={!planName}
       >
-        생성
+        {isEdit ? '수정' : '생성'}
       </StylishButton>
     </Modal>
   );
@@ -97,6 +104,6 @@ const Hr = styled.hr`
   width: 100%;
   height: 1px;
   border: none;
-  background-color: ${({ theme }) => theme.background3};
+  background-color: ${({ theme }) => theme.border1};
 `;
 export default PlanModal;

--- a/src/components/sidebar/classifier/ClassifierTitle.tsx
+++ b/src/components/sidebar/classifier/ClassifierTitle.tsx
@@ -61,6 +61,7 @@ const Container = styled.div`
 const Title = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   column-gap: 8px;
   ${FONT_BOLD_3}
 `;

--- a/src/components/sidebar/classifier/ClassifierTitle.tsx
+++ b/src/components/sidebar/classifier/ClassifierTitle.tsx
@@ -7,6 +7,7 @@ import { FONT_BOLD_3 } from '@/styles/font';
 
 type TProps = {
   title: string;
+  className?: string;
   additionalComponent?: ReactNode;
   titleIcon?: ReactNode;
   isShow?: boolean;
@@ -15,13 +16,14 @@ type TProps = {
 const CLASSIFIER_TITLE_ICON_SIZE = 18;
 
 const ClassifierTitle: React.FC<TProps> = ({
+  className,
   title,
   titleIcon,
   additionalComponent,
   isShow,
 }) => {
   return (
-    <Wrapper>
+    <Container className={className}>
       <Title>
         {titleIcon}
         {title}
@@ -41,11 +43,11 @@ const ClassifierTitle: React.FC<TProps> = ({
           type={isShow ? 'down' : 'up'}
         />
       </div>
-    </Wrapper>
+    </Container>
   );
 };
 
-const Wrapper = styled.div`
+const Container = styled.div`
   width: 100%;
   height: 2.875rem;
   padding: 0.75rem 1.5rem;

--- a/src/stories/modals/PlanModal.stories.tsx
+++ b/src/stories/modals/PlanModal.stories.tsx
@@ -12,10 +12,12 @@ const Template: ComponentStory<typeof PlanModal> = (args) => (
 );
 
 export const Create = Template.bind({});
-Create.args = {};
+Create.args = {
+  onDone: (data) => console.log(data),
+};
 
 export const Update = Template.bind({});
 Update.args = {
-  // isEdit: true,
-  onDone: () => console.log('done'),
+  isEdit: true,
+  onDone: (data) => console.log(data),
 };

--- a/src/stories/modals/PlanModal.stories.tsx
+++ b/src/stories/modals/PlanModal.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PlanModal from '@/components/modal/plan';
+
+export default {
+  title: 'Modals/PlanModal',
+  component: PlanModal,
+} as ComponentMeta<typeof PlanModal>;
+
+const Template: ComponentStory<typeof PlanModal> = (args) => (
+  <PlanModal {...args} />
+);
+
+export const Create = Template.bind({});
+Create.args = {};
+
+export const Update = Template.bind({});
+Update.args = {
+  // isEdit: true,
+  onDone: () => console.log('done'),
+};

--- a/src/styles/planModal.ts
+++ b/src/styles/planModal.ts
@@ -7,8 +7,9 @@ const ClassifierAdditionalMarginRight = '5px';
 const ClassifierAdditionalFontStyle = FONT_REGULAR_7;
 
 const PlanModalClassifierTitle = styled(ClassifierTitle)`
-  padding-left: 0;
-  padding-right: 0;
+  padding: 21px 0;
+  margin-top: 0;
+  height: fit-content;
 `;
 
 export {


### PR DESCRIPTION
## ✨ **구현 기능 명세**

일정생성 모달창을 구현하였습니다.

## 🎁 **주목할 점**

### 일정과 관련된 상태들 관리

![image](https://user-images.githubusercontent.com/32933980/235074804-2477714e-2585-43b3-9860-bf7b1a8b5976.png)

현재는 석훈님과의 충돌 우려로 바로 Zustand의 `SelectedPlan`을 사용할 수 없는 상태입니다. 그래서 지금은 `useState`를 이용하여 각 상태를 관리해주기로 협의하였고, 그렇게 구현하였습니다. 그래서 일정생성 모달창을 구성하는 `/modal/plan/index.tsx`에서 일정들과 관련된 각 상태들 (일정 이름, 메모, 카테고리, 태그 등)을 `useState`로 관리하고 이를 각 부분들에 props로 넘겨주는 형태로 구현하였습니다. 

![image](https://user-images.githubusercontent.com/32933980/235075273-7c49e05d-6092-4fe0-8905-2aa823d11615.png)


그런데 생각해보니 일정의 생성 및 수정과 관련된 상태는 추후에 zustand로 관리 됩니다. 이대로 구현한다면 `/modal/plan/index.tsx` 에서 zustand로부터 상태를 가져와서, props로 각 부분들에 넘겨주는 형태로 바뀔텐데 이는 비효율적이라는 생각이 들었습니다. 그래서 나중에 최대한 변경을 적게 하게 위해서 각 상태는 일정생성 모달 컴포넌트 최상위가 아닌 각 부분들 내부에서 관리하도록 하였습니다. (추후에 각 부분들과 Zustand를 바로 연결하여 사용할 수 있도록)

## 😭 **어려웠던 점**

### Figma와의 차이

기술적인 어려움보다는 그냥 개인적인 미숙함 때문에 비롯된 문제입니다만, 분명 Figma에 작성한대로 구현한 것 같은데 조금씩 어긋나는 부분이나 이질적인 부분 같은 것들이 종종 있는 것 같습니다. 

## 🌄 **스크린샷**

![image](https://user-images.githubusercontent.com/32933980/235075410-fad36b5d-50da-4e10-9772-df0d8e559ed9.png)

![image](https://user-images.githubusercontent.com/32933980/235075377-291653cd-dc81-434c-a193-8404592f9627.png)

![image](https://user-images.githubusercontent.com/32933980/235075758-598d631d-307c-4c25-aa0b-35cfdd58ed07.png)
