### PR TITLE
axios response type 변경

### DIFF
--- a/src/apis/axios/index.ts
+++ b/src/apis/axios/index.ts
@@ -27,7 +27,9 @@ const axiosAPI = (() => {
   );
 
   axiosInstance.interceptors.response.use(
-    (res: AxiosResponse) => res,
+    (res: AxiosResponse) => {
+      return res.data.data;
+    },
     async (error: AxiosError) => {
       const { config, response } = error;
 

--- a/src/apis/axios/index.ts
+++ b/src/apis/axios/index.ts
@@ -8,28 +8,6 @@ import { axiosRefreshAPI } from './refresh';
 import { ACCESS_TOKEN_KEY, SERVER_URL } from '@/constants';
 import { getCookie } from '@/utils/cookie';
 
-declare module 'axios' {
-  export interface Axios {
-    get<T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<T>;
-    delete<T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<T>;
-    post<T, D = any>(
-      url: string,
-      data?: D,
-      config?: AxiosRequestConfig<D>,
-    ): Promise<T>;
-    put<T, D = any>(
-      url: string,
-      data?: D,
-      config?: AxiosRequestConfig<D>,
-    ): Promise<T>;
-    patch<T, D = any>(
-      url: string,
-      data?: D,
-      config?: AxiosRequestConfig<D>,
-    ): Promise<T>;
-  }
-}
-
 const axiosAPI = (() => {
   const axiosInstance = axios.create({
     baseURL: SERVER_URL,
@@ -50,7 +28,10 @@ const axiosAPI = (() => {
 
   axiosInstance.interceptors.response.use(
     (res: AxiosResponse) => {
-      return res.data.data;
+      return {
+        ...res,
+        data: res.data.data,
+      };
     },
     async (error: AxiosError) => {
       const { config, response } = error;

--- a/src/apis/axios/index.ts
+++ b/src/apis/axios/index.ts
@@ -8,6 +8,28 @@ import { axiosRefreshAPI } from './refresh';
 import { ACCESS_TOKEN_KEY, SERVER_URL } from '@/constants';
 import { getCookie } from '@/utils/cookie';
 
+declare module 'axios' {
+  export interface Axios {
+    get<T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<T>;
+    delete<T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<T>;
+    post<T, D = any>(
+      url: string,
+      data?: D,
+      config?: AxiosRequestConfig<D>,
+    ): Promise<T>;
+    put<T, D = any>(
+      url: string,
+      data?: D,
+      config?: AxiosRequestConfig<D>,
+    ): Promise<T>;
+    patch<T, D = any>(
+      url: string,
+      data?: D,
+      config?: AxiosRequestConfig<D>,
+    ): Promise<T>;
+  }
+}
+
 const axiosAPI = (() => {
   const axiosInstance = axios.create({
     baseURL: SERVER_URL,

--- a/src/apis/axios/refresh.ts
+++ b/src/apis/axios/refresh.ts
@@ -9,7 +9,9 @@ const axiosRefreshAPI = (() => {
   });
 
   axiosInstance.interceptors.response.use(
-    (res: AxiosResponse) => res,
+    (res: AxiosResponse) => {
+      return res.data.data;
+    },
     async (error: AxiosError) => {
       return Promise.reject(error);
     },

--- a/src/apis/axios/refresh.ts
+++ b/src/apis/axios/refresh.ts
@@ -10,7 +10,10 @@ const axiosRefreshAPI = (() => {
 
   axiosInstance.interceptors.response.use(
     (res: AxiosResponse) => {
-      return res.data.data;
+      return {
+        ...res,
+        data: res.data.data,
+      };
     },
     async (error: AxiosError) => {
       return Promise.reject(error);

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -4,8 +4,9 @@ import { axiosAPI } from '@/apis/axios';
 import { SERVER_URL } from '@/constants';
 import { IUser } from '@/stores/user';
 
-const getUserAPI = async (): Promise<{ success: boolean; data: IUser }> => {
-  const { data } = await axiosAPI.get(`/user`);
+const getUserAPI = async (): Promise<IUser> => {
+  const data = await axiosAPI.get<IUser>(`/user`);
+
   return data;
 };
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -5,7 +5,7 @@ import { SERVER_URL } from '@/constants';
 import { IUser } from '@/stores/user';
 
 const getUserAPI = async (): Promise<IUser> => {
-  const data = await axiosAPI.get<IUser>(`/user`);
+  const { data } = await axiosAPI.get<IUser>(`/user`);
 
   return data;
 };

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -12,11 +12,9 @@ const useLogin = () => {
 
     (async function checkUser() {
       try {
-        const { success, data } = await getUserAPI();
+        const data = await getUserAPI();
 
-        if (success && data) {
-          setUser(data);
-        }
+        setUser(data);
       } catch (e) {
         // Do Nothing
       } finally {


### PR DESCRIPTION
* Closes #54

## ✨ **구현 기능 명세**
- 기존 `data.data`로 응답하던 데이터 타입을 `data`로 접근 가능하도록 변경합니다.

## 🎁 **주목할 점**
서버 응답시 클라이언트에 반환되는 데이터는 다음과 같습니다.
```js
{
  success: true,
  data: ... 
}
```
해당응답을 react-query에서 사용한다면 `data.data`로 접근해야하는 문제가 발생합니다. 

따라서 `axios interceptor`에 응답 성공시 callback을 등록하여 데이터를 변경합니다.

```ts
  axiosInstance.interceptors.response.use(
    (res: AxiosResponse) => {
      return {
        ...res,
        data: res.data.data,
      };
    },
}
```
