### PR TITLE
Plan Class 의 속성 값을 올바르게 사용할 수 있도록 수정

### DIFF
--- a/src/plan/Plan.ts
+++ b/src/plan/Plan.ts
@@ -14,7 +14,12 @@ class Plan implements IPlan {
 
   constructor(data: IPlan) {
     for (const [key, value] of Object.entries(data)) {
-      Object.defineProperty(this, key, { value, enumerable: true });
+      Object.defineProperty(this, key, {
+        value,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
     }
   }
 
@@ -24,7 +29,9 @@ class Plan implements IPlan {
   set startTime(data: MomentInput) {
     Object.defineProperty(this, 'startTime', {
       value: moment(data).toDate().toUTCString(),
+      configurable: true,
       enumerable: true,
+      writable: true,
     });
   }
   get startMoment(): Moment {
@@ -37,7 +44,9 @@ class Plan implements IPlan {
   set endTime(data: MomentInput) {
     Object.defineProperty(this, 'endTime', {
       value: moment(data).toDate().toUTCString(),
+      configurable: true,
       enumerable: true,
+      writable: true,
     });
   }
   get endMoment(): Moment {
@@ -49,7 +58,12 @@ class Plan implements IPlan {
       this.startTime = this.startMoment.startOf('d').toDate();
       this.endTime = this.endMoment.endOf('d').toDate();
     }
-    Object.defineProperty(this, 'isAllDay', { value: data, enumerable: true });
+    Object.defineProperty(this, 'isAllDay', {
+      value: data,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
   }
 
   get isTimePlan() {

--- a/src/plan/Plan.ts
+++ b/src/plan/Plan.ts
@@ -4,26 +4,28 @@ import { TColor } from '@/types';
 import { IPlan, TPlanType } from '@/types/rq/plan';
 
 class Plan implements IPlan {
-  id!: number;
-  title!: string;
-  description!: string | null;
-  color!: TColor;
-  type!: TPlanType;
-  categoryId!: number | null;
-  tags!: string[];
-  startTime!: string;
-  endTime!: string;
-  isAllDay!: boolean;
+  id: number;
+  title: string;
+  description: string | null;
+  color: TColor;
+  type: TPlanType;
+  categoryId: number | null;
+  tags: string[];
+  startTime: string;
+  endTime: string;
+  isAllDay: boolean;
 
   constructor(data: IPlan) {
-    for (const [key, value] of Object.entries(data)) {
-      Object.defineProperty(this, key, {
-        value,
-        configurable: true,
-        enumerable: true,
-        writable: true,
-      });
-    }
+    this.id = data.id;
+    this.title = data.title;
+    this.description = data.description;
+    this.color = data.color;
+    this.type = data.type;
+    this.categoryId = data.categoryId;
+    this.tags = data.tags;
+    this.startTime = data.startTime;
+    this.endTime = data.endTime;
+    this.isAllDay = data.isAllDay;
   }
 
   set _startTime(data: MomentInput) {

--- a/src/plan/Plan.ts
+++ b/src/plan/Plan.ts
@@ -11,6 +11,9 @@ class Plan implements IPlan {
   type!: TPlanType;
   categoryId!: number | null;
   tags!: string[];
+  startTime!: string;
+  endTime!: string;
+  isAllDay!: boolean;
 
   constructor(data: IPlan) {
     for (const [key, value] of Object.entries(data)) {
@@ -23,47 +26,26 @@ class Plan implements IPlan {
     }
   }
 
-  get startTime(): string {
-    return this.startTime;
-  }
-  set startTime(data: MomentInput) {
-    Object.defineProperty(this, 'startTime', {
-      value: moment(data).toDate().toUTCString(),
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    });
+  set _startTime(data: MomentInput) {
+    this.startTime = moment(data).toDate().toUTCString();
   }
   get startMoment(): Moment {
     return moment(this.startTime).local();
   }
 
-  get endTime(): string {
-    return this.endTime;
-  }
-  set endTime(data: MomentInput) {
-    Object.defineProperty(this, 'endTime', {
-      value: moment(data).toDate().toUTCString(),
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    });
+  set _endTime(data: MomentInput) {
+    this.endTime = moment(data).toDate().toUTCString();
   }
   get endMoment(): Moment {
     return moment(this.endTime).local();
   }
 
-  set isAllDay(data: boolean) {
+  set _isAllDay(data: boolean) {
     if (data) {
-      this.startTime = this.startMoment.startOf('d').toDate();
-      this.endTime = this.endMoment.endOf('d').toDate();
+      this._startTime = this.startMoment.startOf('d').toDate();
+      this._endTime = this.endMoment.endOf('d').toDate();
     }
-    Object.defineProperty(this, 'isAllDay', {
-      value: data,
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    });
+    this.isAllDay = data;
   }
 
   get isTimePlan() {

--- a/src/stores/plan/focusedPlan.ts
+++ b/src/stores/plan/focusedPlan.ts
@@ -23,7 +23,9 @@ interface IFocusedPlanState {
 }
 
 interface IFocusedPlanAction {
-  createDragPlan: (planData: Pick<IPlan, 'startTime'> & Partial<IPlan>) => void;
+  createDragPlan: (
+    planData: Pick<IPlan, 'startTime' | 'endTime'> & Partial<IPlan>,
+  ) => void;
   selectPlan: (plan: Plan) => void;
   onMoveMonthPlan: (args: TMovePlanProps) => void;
   onMoveDayPlan: (args: TMovePlanProps) => void;
@@ -48,7 +50,6 @@ const useFocusedPlanState = create<IFocusedPlanState & IFocusedPlanAction>(
         description: null,
         isAllDay: false,
         type: 'task',
-        endTime: null,
         color: '#52D681',
         categoryId: null,
         tags: [],

--- a/src/types/rq/plan.d.ts
+++ b/src/types/rq/plan.d.ts
@@ -15,7 +15,7 @@ interface IPlan {
   isAllDay: boolean;
   color: TColor;
   startTime: string;
-  endTime: string | null;
+  endTime: string;
   type: TPlanType;
   categoryId: number | null;
   tags: string[];

--- a/src/utils/plan/planViewHandlerToMonth.ts
+++ b/src/utils/plan/planViewHandlerToMonth.ts
@@ -79,18 +79,16 @@ const editPlanView = (props: IEditPlanView) => {
     .hours(currentStart.hours())
     .minutes(currentStart.minutes());
 
-  const endTime = isNaN(termEnd)
-    ? null
-    : targetDate
-        .clone()
-        .add(termEnd, 'd')
-        .hours(currentEnd.hours())
-        .minutes(currentEnd.minutes());
+  const endTime = targetDate
+    .clone()
+    .add(termEnd, 'd')
+    .hours(currentEnd.hours())
+    .minutes(currentEnd.minutes());
 
   const newPlan = {
     ...focusedPlan,
     startTime: startTime.format(),
-    endTime: endTime?.format() || null,
+    endTime: endTime.format(),
   };
 
   return newPlan;


### PR DESCRIPTION
* Closes #71
* Closes #73

## ✨ **구현 기능 명세**

* Plan Class의 `Object.defineProperty` 사용을 지양하기
* Plan Class에서 Setter 함수는 속성과 다른 이름을 가지도록 설정
* Plan Class의 `constructor`에서 속성 지정을 하여 타입을 strict하게 선언
* Plan Class의 `endTime`이 null값을 가지던 것을 수정


## 🎁 **주목할 점**

#71 을 해결하다가 #73 의 해결 방안으로 넘어가게 되었습니다.
버그 설명에 대한 내용은 #73 에 자세하게 설명되어 있습니다.
이후 해결 방안은 함께 결정했습니다.

## 😭 **어려웠던 점**

어떤 방법이 옳은 것인가? 를 고민하게 됐던 것이 함정인 것 같습니다.