### PR TITLE
Dropdown 여닫는 속도 개선

### DIFF
--- a/src/components/common/dropdown/index.tsx
+++ b/src/components/common/dropdown/index.tsx
@@ -1,4 +1,10 @@
-import React, { PropsWithChildren, useState, cloneElement } from 'react';
+import React, {
+  PropsWithChildren,
+  useState,
+  cloneElement,
+  useRef,
+  useEffect,
+} from 'react';
 
 import DropdownController from './DropdownController';
 
@@ -19,10 +25,18 @@ const Dropdown: TDropdown = ({
   duration = 0.35,
 }: TDropdownProps) => {
   const [isShow, setIsShow] = useState<boolean>(defaultVisibility ?? true);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const toggleShow = () => {
     setIsShow((prev) => !prev);
   };
+
+  useEffect(() => {
+    if (!dropdownRef.current) return;
+    dropdownRef.current.style.maxHeight = `${
+      isShow ? dropdownRef.current.scrollHeight : 0
+    }px`;
+  });
 
   children = children ?? [];
   const controllerChildren = Array.prototype.filter
@@ -45,10 +59,10 @@ const Dropdown: TDropdown = ({
       {controllerChildren}
       <div className={className}>
         <div
+          ref={dropdownRef}
           css={[
             {
               paddingTop: '0px',
-              maxHeight: isShow ? '100vh' : '0px',
               overflow: 'hidden',
               transition: `max-height ${duration}s ease-in-out`,
             },


### PR DESCRIPTION
* Closes #89 

## ✨ **구현 기능 명세**

Dropdown을 여닫는 속도를 개선하였습니다.

## 😭 **어려웠던 점**

여러 방법을 거쳐가며 개선할 수 있었습니다. 이 기능을 구현하기 위해 수행하였던 방법들을 소개하겠습니다.

<details>
<summary>
<h3>방법1.  useRef로 열기/닫기 전 길이를 기억하는 방식</h3>
</summary>

```ts

const toggleShow = () => {
    const curHeight = dropdownRef.current?.clientHeight ?? 0;

    // 닫기
    if (isShow) {
      heightRef.current = curHeight;
      dropdownRef.current && (dropdownRef.current.style.height = '0px');
    }
    // 열기
    else {
      dropdownRef.current &&
        (dropdownRef.current.style.height = `${heightRef.current}px`);
    }

    setIsShow((prev) => !prev);
  };

```

![dropdown1](https://github.com/JiPyoTak/plandar-client/assets/32933980/9e161a9c-ec65-4c50-8c1b-27934db3528c)

이 방법의 문제점은 카테고리가 추가되는 경우 새 카테고리가 보여지지 않는다는 점입니다. 왜냐하면 길이를 기억하고 있다가 복원하는 방식이기 때문에 새롭게 추가된 상황에서의 길이는 모르기 때문입니다.
</details>

<details><summary><h3>방법2. 방법1 + getChildrenHeight + useEffect</h3></summary>

```ts
const getChildrenHeight = () => {
    let acc = 0;
    for (const child of dropdownRef.current?.children ?? []) {
      acc += child.clientHeight;
    }
    return acc;
  };

  const toggleShow = () => {
    // 닫기
    if (isShow) {
      dropdownRef.current && (dropdownRef.current.style.height = '0px');
    }
    // 열기
    else {
      dropdownRef.current &&
        (dropdownRef.current.style.height = `${getChildrenHeight()}px`);
    }

    setIsShow((prev) => !prev);
  };

  useEffect(() => {
    if (isShow) {
      dropdownRef.current &&
        (dropdownRef.current.style.height = `${getChildrenHeight()}px`);
    }
  }, [dropdownRef.current?.children.length]);
```

![dropdown1](https://github.com/JiPyoTak/plandar-client/assets/32933980/c3b4d800-6af0-4d3a-a9a0-3bd49bb0bd1a)

이 방법의 문제점은 카테고리가 추가되거나 삭제되는 경우처럼 children.length가 변하는 경우에는 잘 반영이 됩니다. 하지만 위처럼 children.length가 변하는 경우가 아닌 한 child의 높이가 변하는 경우는 감지하지 못한다는 점입니다.

</details>

<details><summary><h3>방법3. height: fit-content</h3></summary>

```ts
height: 'fit-content',
transition: `height ${duration}s ease-in-out`,
```

fit-content는 transition이 적용되지 않아서 이 방법은 실패하였습니다.

</details>

<details><summary><h3>방법4. maxHeight와 getChildrenHeight</h3></summary>

```ts
const getChildrenHeight = () => {
    let acc = 0;
    for (const child of ref.current?.children ?? []) {
      acc += child.clientHeight;
    }
    return acc;
  };


maxHeight: isShow ? `${getChildrenHeight()}px` : '0px',
transition: `max-height ${duration}s ease-in-out`,
```

![dropdown1](https://github.com/JiPyoTak/plandar-client/assets/32933980/1d18b32c-31d5-4caf-bf5f-d6b3783cedda)

이 방법의 문제점은 매렌더링마다 for문을 돌면서 height를 계산한다는 점입니다. 이 코드를 보고 석훈님이 `scrollHeight`를 사용하면 된다고 조언해주셨습니다.

</details>

<details><summary><h3>최종방법. scrollHeight + useEffect</h3></summary>

```ts
const toggleShow = () => {
    setIsShow((prev) => !prev);
  };

  useEffect(() => {
    if (!dropdownRef.current) return;
    dropdownRef.current.style.maxHeight = `${
      isShow ? dropdownRef.current.scrollHeight : 0
    }px`;
  });

transition: `max-height ${duration}s ease-in-out`,
```

![dropdown1.gif](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/b79a2fba-223f-4f60-b775-c24d4dbb3fcb/dropdown1.gif)

deps 배열이 없는 useEffect에서 scrollHeight를 사용하여 기능을 구현하였습니다. useEffect의 deps 배열로 `[isShow, dropdownRef.current?.scrollHeight]` 를 넣어주어도 된다고 생각하였는데, 이렇게 넣어주면 다음처럼 동작합니다.

![dropdown1.gif](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/7f832f7c-61fc-4f09-a7f3-7a12ef68d72e/dropdown1.gif)

`안녕`을 입력하면 바로 선택할 수 있는 창이 나와야 하는데 나오지 않는 문제가 있었습니다.

</details>

<details><summary><h3>keyframes와 관련된 삽질</h3></summary>

아직 emotion을 다루는데 미숙하다는 것을 깨달았습니다.

```ts
<div
          ref={dropdownRef}
          css={[
            css`
              animation: ${heightAni(isShow ? height : 0)} ${duration}s
                ease-in-out;
            `,
            {
              paddingTop: '0px',
              overflow: 'hidden'
            },
          ]}
        >
          {itemChildren}
        </div>

const heightAni = (to: number) => keyframes`
  100% {
    height: ${to}px;
  }
`;

```

위처럼 keyframes 애니메이션을 적용하려고 했는데 동작이 안되더라구요... 좀 더 공부해야겠습니다.

</details>

## 🌄 **스크린샷**

![dropdown1](https://github.com/JiPyoTak/plandar-client/assets/32933980/6c281865-e739-4e83-a726-e9acea5e68eb)

![dropdown1](https://github.com/JiPyoTak/plandar-client/assets/32933980/d5956d4a-35e0-4d6e-a242-2fb34d556be0)
