### PR TITLE
일정 생성 모달창 api 연결

### DIFF
--- a/src/apis/axios/index.ts
+++ b/src/apis/axios/index.ts
@@ -41,7 +41,7 @@ const axiosAPI = (() => {
       }
 
       if (response?.status !== 401) {
-        return error;
+        return Promise.reject(error);
       }
 
       try {

--- a/src/components/modal/plan/PlanTag.tsx
+++ b/src/components/modal/plan/PlanTag.tsx
@@ -19,12 +19,20 @@ import {
 const PlanTag: React.FC = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [tagInput, setTagInput] = useState('');
-  const [selectedTags, setSelectedTags] = useFocusedPlanState((store) => {
-    const { focusedPlan, updateFocusedPlan } = store;
-    const setSelectedTags = (newTags: string[]) =>
-      updateFocusedPlan({ tags: newTags });
-    return [focusedPlan?.tags || [], setSelectedTags];
-  }, shallow);
+  const [selectedTags, setSelectedTags] = useFocusedPlanState(
+    (store) => {
+      const { focusedPlan, updateFocusedPlan } = store;
+      const setSelectedTags = (newTags: string[]) =>
+        updateFocusedPlan({ tags: newTags });
+      return [focusedPlan?.tags || [], setSelectedTags];
+    },
+    (prev, cur) => {
+      const prevTags = prev[0];
+      const curTags = cur[0];
+      if (prevTags.length !== curTags.length) return false;
+      return prevTags.every((tag, i) => tag === curTags[i]);
+    },
+  );
 
   // selectedTags에 태그 추가
   const addTag = (tag?: string) => {

--- a/src/hooks/rq/plan.ts
+++ b/src/hooks/rq/plan.ts
@@ -114,7 +114,7 @@ const useCreatePlanMutation = () => {
 const useUpdatePlanMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<IPlan, unknown, TPlanInput>(updatePlanApi, {
+  return useMutation<IPlan, unknown, IPlan>(updatePlanApi, {
     onSuccess(data, variables) {
       // 기존 일정을 제거
       const prev = queryClient.getQueryData<IPlan>(['plan', { id: data.id }]);


### PR DESCRIPTION
* Closes #85 

## ✨ **구현 기능 명세**

일정생성 모달창과 석호님이 작성하셨던 React Query를 이용한 일정 api를 연결하였습니다.

## 🎁 **주목할 점**

### QueryClient를 인자로 넘겨주기

존 작성된 `addQueriesData`와 `removeQueriesData`는 내부에서 `useQueryClient`를 통해 QueryClient를 가져와서 사용하려고 했습니다. 그런데 각 함수들은 React 트리 내에서 동작하는 함수가 아닙니다. 그렇기 때문에 `useContext`를 사용하는 `useQueryClient`가 동작할 수 없어서 에러가 발생하였습니다.

이 문제를 해결하기 위해 인자로 `QueryClient` 객체를 넘겨주었습니다. `addQueriesData`와 `removeQueriesData`는 React 트리 내에서 동작하는 함수들에 의해 호출됩니다. 이 함수들은 `useContext`를 사용할 수 있으므로 이 함수들이 `addQueriesData`와 `removeQueriesData`를 호출할 때 QueryClient 객체를 넘겨줌으로써 해결하였습니다.

## 😭 **고려해야할 점**

현재 일정생성 모달창을 구성하고 있는 최상위 노드(src/components/modal/plan/index.tsx)에서 store의 `focusedPlan`을 참조하고 있습니다. 이로 인해 focusedPlan이 바뀌면(업데이트되면) 모달창 전체가 리렌더링됩니다. 

간단히 해결하려면 하위 노드들에 React.memo를 사용할 수 있습니다. 아래코드처럼 일정생성 모달창을 구성하고 있는 각 부분들(컴포넌트들)에 props로 넘겨주는 값이 없으므로 React.memo의 오버드가 크지 않기 때문에 사용해도 괜찮을 것 같습니다. 그래도 혹시 Zustand를 사용해서 발생하는 리렌더링인 만큼 Zustand로 해결할 수 있는 방법이 있을지 좀 더 고민해보겠습니다.

```tsx
// src/components/modal/plan/index.tsx

return (
      ....
      <PlanTitleInput />
      <DateDisplay />
      <PlanAllDay />
      <Hr />
      <PlanMemo />
      <Hr />
      <PlanCategory />
      <Hr />
      <PlanTag />
      ...
)
```

