### PR TITLE
큰 달력 일정 API 연결

### DIFF
--- a/src/apis/plan.ts
+++ b/src/apis/plan.ts
@@ -16,7 +16,7 @@ const createPlanApi = async (input: TPlanInput) => {
   return data;
 };
 
-const updatePlanApi = async ({ id, ...input }: Partial<IPlan>) => {
+const updatePlanApi = async ({ id, ...input }: TPlanInput) => {
   const { data } = await axiosAPI.put(`/plan/${id}`, input);
 
   return data;

--- a/src/components/calendars/large/CalendarLayer.tsx
+++ b/src/components/calendars/large/CalendarLayer.tsx
@@ -2,6 +2,8 @@ import React, { memo, useCallback } from 'react';
 
 import styled from '@emotion/styled';
 
+import { shallow } from 'zustand/shallow';
+
 import DayPlan from '@/components/plan/DayPlan';
 import DaysPlanManager from '@/plan/DaysPlanManager';
 import Plan from '@/plan/Plan';
@@ -13,16 +15,31 @@ interface IProps {
 }
 
 const CalendarLayer = ({ planManager }: IProps) => {
-  const { focusedPlan, moveDragPlan } = useFocusedPlanState();
-  const { hoveredPlan, setHoveredPlan, clearHoveredPlan } =
-    useHoveredPlanState();
+  const { isDragging, focusedPlanId, moveDragPlan } = useFocusedPlanState(
+    (store) => ({
+      isDragging: store.isDragging,
+      focusedPlanId: store.focusedPlan?.id,
+      moveDragPlan: store.moveDragPlan,
+    }),
+    shallow,
+  );
+
+  const { hoveredPlanId, setHoveredPlan, clearHoveredPlan } =
+    useHoveredPlanState(
+      (store) => ({
+        hoveredPlanId: store.hoveredPlan?.id,
+        setHoveredPlan: store.setHoveredPlan,
+        clearHoveredPlan: store.clearHoveredPlan,
+      }),
+      shallow,
+    );
 
   const plans = planManager.plans;
   const viewPlans = planManager.viewInfo;
 
   const onMouseEnter = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, plan: Plan) => {
-      if (focusedPlan) return;
+      if (isDragging) return;
 
       const target = e.currentTarget as HTMLElement;
 
@@ -33,7 +50,7 @@ const CalendarLayer = ({ planManager }: IProps) => {
         rect: { top, left, right, bottom },
       });
     },
-    [focusedPlan?.id],
+    [isDragging],
   );
 
   const onMouseDown = useCallback((plan: Plan) => {
@@ -53,8 +70,8 @@ const CalendarLayer = ({ planManager }: IProps) => {
             key={i}
             plan={plan}
             view={viewPlan}
-            isSelected={focusedPlan?.id === plan.id}
-            isHovered={hoveredPlan?.id === plan.id}
+            isSelected={focusedPlanId === plan.id}
+            isHovered={hoveredPlanId === plan.id}
             onMouseEnter={onMouseEnter}
             onMouseDown={onMouseDown}
             onMouseLeave={clearHoveredPlan}

--- a/src/components/calendars/large/CalendarOverlay.tsx
+++ b/src/components/calendars/large/CalendarOverlay.tsx
@@ -12,18 +12,16 @@ interface IProps {
 const CalendarOverlay = ({ week }: IProps) => {
   const { year, month } = useDateState();
 
-  const getBackground = (y: number, m: number) => {
-    if (y === year && m === month) return 'transparent';
-    return 'rgba(255,255,255,.5)';
-  };
-
   return (
     <Container>
       {week.map(({ year: y, month: m }, j) => (
         <Inner
           key={`${y}${m}${j}`}
           css={{
-            backgroundColor: getBackground(y, m),
+            backgroundColor:
+              y === year && m === month
+                ? 'transparent'
+                : 'rgba(255,255,255,.4)',
           }}
         />
       ))}

--- a/src/components/calendars/large/CalendarWeek.tsx
+++ b/src/components/calendars/large/CalendarWeek.tsx
@@ -14,7 +14,10 @@ interface IProps {
 }
 
 const CalendarWeek = ({ week, index, daysIndex, onMouseDown }: IProps) => {
-  const { day } = useDateState();
+  const day = useDateState(
+    (store) => store.day,
+    (prev, next) => prev === next,
+  );
 
   return (
     <Container>

--- a/src/hooks/rq/plan.ts
+++ b/src/hooks/rq/plan.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
   createPlanApi,
@@ -7,6 +12,7 @@ import {
   updatePlanApi,
 } from '@/apis/plan';
 
+import Plan from '@/plan/Plan';
 import { IPlan, TPlanInput } from '@/types/rq/plan';
 import { getFormattedDate } from '@/utils/date/getFormattedDate';
 import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
@@ -29,7 +35,7 @@ const executeCallbackByDate = (
     endYMD.year * 12 + endYMD.month - (startYMD.year * 12 + startYMD.month);
 
   // 일정의 시작, 끝 날짜를 기준으로 해당 일정이 포함되는 달의 일정을 모두 가져옴
-  for (let i = 0; i <= diff; i++) {
+  for (let i = -1; i <= diff; i++) {
     const YMD = {
       year: startYMD.year + Math.floor((startYMD.month + i) / 12),
       month: ((startYMD.month + i) % 12) + 1,
@@ -43,24 +49,23 @@ const executeCallbackByDate = (
   }
 };
 
-const addQueriesData = (data: IPlan) => (timemin: string, timemax: string) => {
-  const queryClient = useQueryClient();
+const addQueriesData =
+  (data: IPlan, queryClient: QueryClient) =>
+  (timemin: string, timemax: string) => {
+    const key = ['plans', { timemin, timemax }];
 
-  const key = ['plans', { timemin, timemax }];
+    const prevData = queryClient.getQueryData<IPlan[] | undefined>(key);
 
-  const prevData = queryClient.getQueryData<IPlan[] | undefined>(key);
+    if (!prevData) return;
 
-  if (!prevData) return;
-
-  queryClient.setQueriesData<IPlan[]>(key, (oldData) => {
-    return [...(oldData ?? []), data];
-  });
-};
+    queryClient.setQueriesData<IPlan[]>(key, (oldData) => {
+      return [...(oldData ?? []), new Plan(data)];
+    });
+  };
 
 const removeQueriesData =
-  (id: number) => (timemin: string, timemax: string) => {
-    const queryClient = useQueryClient();
-
+  (id: number, queryClient: QueryClient) =>
+  (timemin: string, timemax: string) => {
     const key = ['plans', { timemin, timemax }];
 
     const prevData = queryClient.getQueryData<IPlan[] | undefined>(key);
@@ -81,10 +86,11 @@ const useGetPlansQuery = ({ timemin, timemax }: IGetPlansPayload) => {
     ['plans', { timemin, timemax }],
     () => getPlansApi({ timemin, timemax }),
     {
+      staleTime: 1000 * 60 * 60 * 24,
       onSuccess(data) {
-        for (let i = 0; i < data.length; i++) {
-          queryClient.setQueryData(['plan', { id: data[i].id }], data[i]);
-        }
+        data.forEach((plan) =>
+          queryClient.setQueryData(['plan', { id: plan.id }], new Plan(plan)),
+        );
       },
     },
   );
@@ -98,10 +104,10 @@ const useCreatePlanMutation = () => {
     onSuccess(data, variables) {
       const { startTime, endTime } = variables;
 
-      const callback = addQueriesData(data);
+      const callback = addQueriesData(data, queryClient);
 
       executeCallbackByDate(startTime, endTime, callback);
-      queryClient.setQueryData(['plan', { id: data.id }], data);
+      queryClient.setQueryData(['plan', { id: data.id }], new Plan(data));
     },
   });
 };
@@ -113,23 +119,24 @@ const useUpdatePlanMutation = () => {
   return useMutation<IPlan, unknown, TPlanInput>(updatePlanApi, {
     onSuccess(data, variables) {
       // 기존 일정을 제거
-      const prev = queryClient.getQueryData<IPlan>(['plan', { id: data.id }]);
+      const prev = queryClient.getQueryData<Plan>(['plan', { id: data.id }]);
 
       if (!prev) return;
 
       const { startTime, endTime } = prev;
 
-      const cbByRemove = removeQueriesData(data.id);
+      const cbByRemove = removeQueriesData(data.id, queryClient);
 
       executeCallbackByDate(startTime, endTime, cbByRemove);
 
       // 변경된 일정을 추가
       const { startTime: newStartTime, endTime: newEndTime } = variables;
 
-      const cbByAdd = addQueriesData(data);
+      const cbByAdd = addQueriesData(data, queryClient);
 
       executeCallbackByDate(newStartTime, newEndTime, cbByAdd);
-      queryClient.setQueryData(['plan', { id: data.id }], data);
+
+      queryClient.setQueryData(['plan', { id: data.id }], new Plan(data));
     },
   });
 };
@@ -141,7 +148,7 @@ const useDeletePlanMutation = () => {
     onSuccess(data, variables) {
       const { startTime, endTime } = data;
 
-      const callback = removeQueriesData(variables);
+      const callback = removeQueriesData(variables, queryClient);
 
       executeCallbackByDate(startTime, endTime, callback);
       queryClient.removeQueries(['plan', { id: data.id }]);

--- a/src/plan/Plan.ts
+++ b/src/plan/Plan.ts
@@ -2,6 +2,7 @@ import moment, { Moment, MomentInput } from 'moment';
 
 import { TColor } from '@/types';
 import { IPlan, TPlanType } from '@/types/rq/plan';
+import { ITag } from '@/types/rq/tag';
 
 class Plan implements IPlan {
   id: number;
@@ -10,7 +11,7 @@ class Plan implements IPlan {
   color: TColor;
   type: TPlanType;
   categoryId: number | null;
-  tags: string[];
+  tags: ITag[];
   startTime: string;
   endTime: string;
   isAllDay: boolean;

--- a/src/stores/plan/focusedPlan.ts
+++ b/src/stores/plan/focusedPlan.ts
@@ -54,6 +54,7 @@ const useFocusedPlanState = create<IFocusedPlanState & IFocusedPlanAction>(
         type: 'create',
         focusedPlan: newPlan,
         currentPlan: newPlan,
+        isDragging: true,
       });
     },
     moveDragPlan: (plan) => {
@@ -61,6 +62,7 @@ const useFocusedPlanState = create<IFocusedPlanState & IFocusedPlanAction>(
         type: 'move',
         focusedPlan: new Plan(plan),
         currentPlan: plan,
+        isDragging: true,
       });
     },
     editDragPlan: (plan) => {

--- a/src/types/rq/plan.d.ts
+++ b/src/types/rq/plan.d.ts
@@ -1,5 +1,7 @@
 import { TColor } from '..';
 
+import { ITag } from './tag';
+
 export const EPlanType = {
   EVENT: 'event',
   TASK: 'task',
@@ -18,9 +20,12 @@ interface IPlan {
   endTime: string;
   type: TPlanType;
   categoryId: number | null;
-  tags: string[];
+  tags: ITag[];
 }
 
-type TPlanInput = Omit<IPlan, 'id'>;
+interface TPlanInput extends Omit<IPlan, 'id' | 'tags'> {
+  id?: number;
+  tags: string[];
+}
 
 export type { IPlan, TPlanType, TPlanInput };


### PR DESCRIPTION
* #94 

## ✨ **구현 기능 명세**
- 생성된 일정 hook을 큰 달력과 연결합니다.
- 아직 몇 가지 기능이 완성되지 않았지만 TimeTable과 관련된 기능이 있어 작성한 내용만 우선적으로 병합하고자 합니다.

## 🎁 **주목할 점**
### 종일 일정이 아니지만 여러날짜에 걸쳐 생성된 일정

- 현재 큰 달력은 종일 일정을 보여쥬고 있습니다.
- 당초 계획은 종일 일정이 아닐경우 하니의 셀에 일정을 생성할 예정이었습니다.
- 하지만 종일 일정이 아니지만 이틀에 걸쳐 24시간 이하의 일정이 생성됨에 따라 기존 data에서 시작날짜와 종료날짜가 같지 않은 일정을 찾아야했습니다.
- 다만 해당 기능은 따로 브랜치를 분리하여 진행하는 것이 PR 단위를 최소화하는데 도움이 될 것이라 판단해 해당 PR에 추가하지 않았습니다.

### mouse click에 따라 다른 이벤트

- 일정을 수정하기 위해선 기존 일정을 클릭한 상태로 마우스를 움직여야합니다.
- 생성된 일정의 상세 정보를 확인하기 위해선 기존 일정을 클릭해야합니다.
- 현재 두가지 기능이 충돌됨에 따라 브랜치를 분리하여 진행하는게 맞다고 생각합니다.
- 우선적으로 해당 기능부터 진행할 예정입니다.

## 😭 **어려웠던 점**
- 정리하니 할게 많아진 느낌입니다ㅠㅠ

