### PR TITLE
월간 달력에서 TimePlan 렌더링

### DIFF
--- a/src/components/calendars/large/CalendarCell.tsx
+++ b/src/components/calendars/large/CalendarCell.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import styled from '@emotion/styled';
 
 import Day from '@/components/common/calendar/CalendarDay';
+import DayTimePlan from '@/components/plan/DayTimePlan';
 import Plan from '@/plan/Plan';
 import useDateState from '@/stores/date';
 import { ICalendarInfo } from '@/utils/calendar/getCalendarInfo';
@@ -46,7 +47,11 @@ const CalendarCell: React.FC<IProps> = (props) => {
         onClick={onChangeStoreDate}
       />
       <div style={{ height }} />
-      <div>{timePlans.map((t) => t.title)}</div>
+      <TimePlanList>
+        {timePlans.map((timePlan) => (
+          <DayTimePlan plan={timePlan} />
+        ))}
+      </TimePlanList>
     </Container>
   );
 };
@@ -75,6 +80,11 @@ const CellDay = styled(Day)`
   justify-content: flex-start;
 
   padding: 4px;
+`;
+
+const TimePlanList = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 export default memo(CalendarCell);

--- a/src/components/calendars/large/CalendarCell.tsx
+++ b/src/components/calendars/large/CalendarCell.tsx
@@ -68,6 +68,9 @@ const Container = styled.div<Pick<IProps, 'isLastDay' | 'isLastWeek'>>`
 
   cursor: pointer;
 
+  // fix when give min-width
+  overflow: hidden;
+
   &.isDragging,
   &.isDragging * {
     cursor: grabbing !important;

--- a/src/components/plan/DayTimePlan.tsx
+++ b/src/components/plan/DayTimePlan.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+
+import Plan from '@/plan/Plan';
+
+type TProps = {
+  plan: Plan;
+};
+
+const DayTimePlan: React.FC<TProps> = ({ plan }) => {
+  return <Container></Container>;
+};
+
+const Container = styled.div``;
+
+export default DayTimePlan;

--- a/src/components/plan/DayTimePlan.tsx
+++ b/src/components/plan/DayTimePlan.tsx
@@ -2,16 +2,40 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
+import { Color } from '@/components/common/modal/styles';
 import Plan from '@/plan/Plan';
+import { FONT_REGULAR_5 } from '@/styles/font';
 
 type TProps = {
   plan: Plan;
 };
 
 const DayTimePlan: React.FC<TProps> = ({ plan }) => {
-  return <Container></Container>;
+  return (
+    <Container>
+      <div css={{ flex: '0 0 16px' }}>
+        <Color width={8} height={8} backgroundColor={plan.color} />
+      </div>
+      <TitleText>{plan.title}</TitleText>
+    </Container>
+  );
 };
 
-const Container = styled.div``;
+const Container = styled.div`
+  height: 1.25rem;
+  padding: 0 0.5rem;
+
+  display: flex;
+  align-items: center;
+`;
+
+const TitleText = styled.span`
+  ${FONT_REGULAR_5}
+
+  flex: 1 1 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
 
 export default DayTimePlan;

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import { useEffect, useReducer } from 'react';
 
 import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import moment from 'moment';
 
 import CalendarView from '@/components/calendars/large';
@@ -37,6 +38,8 @@ const Template: ComponentStory<typeof CalendarView> = () => {
     ...getStartAndEndDate({ year, month, day }),
   );
   const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
+  const queryClient = useQueryClient();
+  const forceUpdate = useReducer(() => ({}), {})[1];
 
   const addRandomAlldayPlan = () => {
     const daysInMonth = moment({ year, month: month - 1, day }).daysInMonth();
@@ -79,6 +82,12 @@ const Template: ComponentStory<typeof CalendarView> = () => {
     );
   };
 
+  const clearPlans = () => {
+    planStubManager.clear();
+    queryClient.clear();
+    forceUpdate();
+  };
+
   return (
     <Container>
       <div className="large-calendar-controls">
@@ -88,6 +97,7 @@ const Template: ComponentStory<typeof CalendarView> = () => {
         <TestButton onClick={addRandomTimePlan}>
           범위 안 시간 일정 추가하기
         </TestButton>
+        <TestButton onClick={clearPlans}>전체 일정 삭제하기</TestButton>
       </div>
       <div className="large-calendar-main">
         <CalendarView />

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -36,7 +36,7 @@ const Template: ComponentStory<typeof CalendarView> = () => {
   const { startFormat } = getFormattedDate(
     ...getStartAndEndDate({ year, month, day }),
   );
-  const { mutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
 
   const addRandomAlldayPlan = () => {
     const daysInMonth = moment({ year, month: month - 1, day }).daysInMonth();
@@ -47,11 +47,34 @@ const Template: ComponentStory<typeof CalendarView> = () => {
     const startTime = moment(startOfMonth).add(startGap, 'days');
     const endTime = moment(startTime).add(planTerm, 'days');
 
-    mutateAsync(
+    createMutateAsync(
       planStubManager.createStub({
         isAllDay: true,
         startTime: startTime.toString(),
         endTime: endTime.toString(),
+      }),
+    );
+  };
+
+  const addRandomTimePlan = () => {
+    const startOfMonth = moment(startFormat);
+    const startDay = Math.round(Math.random() * 42);
+    const startHour = Math.round(Math.random() * 21);
+    const startMinute = Math.round(Math.random() * 59);
+    const startPeriod = startHour * 60 + startMinute;
+
+    const startTime = moment(startOfMonth)
+      .add(startDay, 'days')
+      .add(startPeriod, 'minutes');
+
+    const periodMinutes = Math.round(Math.random() * (24 * 60 - 16)) + 15;
+    const endTime = moment(startTime).add(periodMinutes, 'minutes');
+
+    createMutateAsync(
+      planStubManager.createStub({
+        isAllDay: false,
+        startTime,
+        endTime,
       }),
     );
   };
@@ -61,6 +84,9 @@ const Template: ComponentStory<typeof CalendarView> = () => {
       <div className="large-calendar-controls">
         <TestButton onClick={addRandomAlldayPlan}>
           범위 안 종일 일정 추가하기
+        </TestButton>
+        <TestButton onClick={addRandomTimePlan}>
+          범위 안 시간 일정 추가하기
         </TestButton>
       </div>
       <div className="large-calendar-main">


### PR DESCRIPTION
- Closes #100

~~#107 에 이어서 작업된 환경입니다.
**해당 Pull Request가 닫히면 파일 Review 바랍니다.**~~

## ✨ **구현 기능 명세**

월간 달력에서 TimePlan을 렌더링 할 수 있도록 합니다.

1. Large Calendar 의 Storybook 에서 테스팅 추가
    시간 일정을 추가하여 테스팅 할 수 있도록 로직을 추가했습니다.
2. TimePlan 스타일링
    `DayTimePlan`이라는 컴포넌트를 하나 생성했고 이를 통해 렌더링하고 있습니다.

## 🌄 **스크린샷**

![추가](https://github.com/JiPyoTak/plandar-client/assets/55688122/80b66480-2a14-464c-b834-66ac3737b817)
