### PR TITLE
Timetable Plans를 React-Query로 받아오도록 설정

### DIFF
--- a/src/components/timetable/TimetableHeader.tsx
+++ b/src/components/timetable/TimetableHeader.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import styled from '@emotion/styled';
 import moment, { Moment } from 'moment';
 
+import TimetableScroller from './TimetableScroller';
 import CalendarDay from '@/components/common/calendar/CalendarDay';
 
-import TimetableScroller from './TimetableScroller';
 import { DAY_OF_WEEK_UNIT } from '@/constants';
 import useDateState from '@/stores/date';
 import { FONT_REGULAR_5 } from '@/styles/font';
@@ -51,8 +51,8 @@ const TimetableHeader: React.FC<TProps> = ({ dateMoments }) => {
           const { year, month, day } = calendarInfo;
 
           return (
-            <DaySizer>
-              <DayContent key={calendarInfo.format}>
+            <DaySizer key={calendarInfo.format}>
+              <DayContent>
                 <DayNumber
                   {...calendarInfo}
                   onClick={() => onChangeStoreDate({ year, month, day })}

--- a/src/components/timetable/view/index.tsx
+++ b/src/components/timetable/view/index.tsx
@@ -5,9 +5,9 @@ import { Moment } from 'moment';
 
 import TimetableColumns from './columns';
 import TimetableAllDay from './TimetableAllDay';
+import { useGetPlansQuery } from '@/hooks/rq/plan';
 import usePlanDrag from '@/hooks/usePlanDrag';
 import useDateState from '@/stores/date';
-import planStubManager from '@/stories/apis/data/plan';
 import { getFormattedDate } from '@/utils/date/getFormattedDate';
 import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 import { divideTimePlans } from '@/utils/plan/divideTimePlans';
@@ -19,19 +19,17 @@ type TProps = {
 const TimetableView: React.FC<TProps> = ({ dateMoments }) => {
   const { onMouseMove, changeCurrentDate } = usePlanDrag();
 
-  // TODO : React-Query를 이용해 Plans 가져오기
   const { year, month, day } = useDateState();
   const { startFormat, endFormat } = getFormattedDate(
     ...getStartAndEndDate({ year, month, day }),
   );
-
-  const plans = planStubManager.get({
-    timeMin: startFormat,
-    timeMax: endFormat,
+  const { data: plans } = useGetPlansQuery({
+    timemin: startFormat,
+    timemax: endFormat,
   });
 
   // 종일, 시간에 들어가야 할 일정 분류하기
-  const { timePlans, allDayPlans } = divideTimePlans(plans);
+  const { timePlans, allDayPlans } = divideTimePlans(plans ?? []);
 
   return (
     <>

--- a/src/stories/apis/data/plan.ts
+++ b/src/stories/apis/data/plan.ts
@@ -109,6 +109,7 @@ class PlanStubManager {
   }
 
   public clear() {
+    this.id = 0;
     for (let i = this.data.length; i >= 0; i--) {
       delete this.data[i];
     }

--- a/src/stories/timetable/DayTimetable.stories.tsx
+++ b/src/stories/timetable/DayTimetable.stories.tsx
@@ -10,6 +10,12 @@ import planStubManager from '../apis/data/plan';
 import Timetable from '@/components/timetable';
 import useDateState from '@/stores/date';
 import useCalendarUnitState from '@/stores/date/calendarUnit';
+import {
+  createPlanApiHandler,
+  deletePlanApiHandler,
+  getPlansApiHandler,
+  updatePlanApiHandler,
+} from '@/stories/apis/plan';
 import { padZero } from '@/utils/padZero';
 
 export default {
@@ -115,3 +121,13 @@ const TestButton = styled.button`
 
 export const DayTimetable = AddableTemplate.bind({});
 DayTimetable.args = { rangeAmount: 1 };
+DayTimetable.parameters = {
+  msw: {
+    handlers: [
+      getPlansApiHandler,
+      createPlanApiHandler,
+      updatePlanApiHandler,
+      deletePlanApiHandler,
+    ],
+  },
+};

--- a/src/stories/timetable/WeekTimetable.stories.tsx
+++ b/src/stories/timetable/WeekTimetable.stories.tsx
@@ -9,6 +9,12 @@ import Timetable from '@/components/timetable';
 import useDateState from '@/stores/date';
 import useCalendarUnitState from '@/stores/date/calendarUnit';
 import planStubManager from '@/stories/apis/data/plan';
+import {
+  createPlanApiHandler,
+  deletePlanApiHandler,
+  getPlansApiHandler,
+  updatePlanApiHandler,
+} from '@/stories/apis/plan';
 
 export default {
   title: 'timetable/DayTimetable',
@@ -136,3 +142,13 @@ const TestButton = styled.button`
 
 export const WeekTimetable = Template.bind({});
 WeekTimetable.args = { rangeAmount: 7 };
+WeekTimetable.parameters = {
+  msw: {
+    handlers: [
+      getPlansApiHandler,
+      createPlanApiHandler,
+      updatePlanApiHandler,
+      deletePlanApiHandler,
+    ],
+  },
+};

--- a/src/stories/timetable/WeekTimetable.stories.tsx
+++ b/src/stories/timetable/WeekTimetable.stories.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer } from 'react';
 
 import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import moment from 'moment';
 
 import Timetable from '@/components/timetable';
+import { useCreatePlanMutation } from '@/hooks/rq/plan';
 import useDateState from '@/stores/date';
 import useCalendarUnitState from '@/stores/date/calendarUnit';
 import planStubManager from '@/stories/apis/data/plan';
@@ -25,13 +27,16 @@ export default {
 } as ComponentMeta<typeof Timetable>;
 
 const Template: ComponentStory<typeof Timetable> = (args) => {
-  const setId = useState<number>(1)[1];
   const { year, month, day } = useDateState();
 
   const { selectCalendarUnit } = useCalendarUnitState();
   useEffect(() => {
     selectCalendarUnit('주');
   }, []);
+
+  const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
+  const queryClient = useQueryClient();
+  const forceUpdate = useReducer(() => ({}), {})[1];
 
   const addRandomAlldayPlan = () => {
     const startOfWeek = moment(`${year}-${month}-${day}`).startOf('week');
@@ -44,17 +49,13 @@ const Template: ComponentStory<typeof Timetable> = (args) => {
       : startTime;
     const endTime = moment(minimumMoment).add(planTerm, 'days');
 
-    setId((prevId) => {
+    createMutateAsync(
       planStubManager.add({
-        id: prevId,
-        title: `임시 데이터 ${prevId}`,
         isAllDay: true,
         startTime,
         endTime,
-      });
-
-      return prevId + 1;
-    });
+      }),
+    );
   };
 
   const addRandomTimePlan = () => {
@@ -71,17 +72,13 @@ const Template: ComponentStory<typeof Timetable> = (args) => {
     const periodMinutes = Math.round(Math.random() * (24 * 60 - 16)) + 15;
     const endTime = moment(startTime).add(periodMinutes, 'minutes');
 
-    setId((prevId) => {
+    createMutateAsync(
       planStubManager.add({
-        id: prevId,
-        title: `임시 데이터 ${prevId}`,
         isAllDay: false,
         startTime,
         endTime,
-      });
-
-      return prevId + 1;
-    });
+      }),
+    );
   };
 
   const addPlanGroup = () => {
@@ -92,7 +89,8 @@ const Template: ComponentStory<typeof Timetable> = (args) => {
 
   const clearPlans = () => {
     planStubManager.clear();
-    setId(1);
+    queryClient.clear();
+    forceUpdate();
   };
 
   return (


### PR DESCRIPTION
- Closes #109

## ✨ **구현 기능 명세**

이미 만들어져있는 React-Query 로직을 사용하니 정말 쉽게 진행했습니다!

### TimetableView에서 서버를 통해 Plans 가져오기

`useGetPlansQuery` 를 이용해서 plans 값을 가져오도록 설정했습니다.
월간 달력과 같이 주간, 일간 달력에서도 해당 달을 key로 하여금 가져오도록 합니다.

### Timetable의 Storybook

Storybook에서도 mocked API를 사용하도록 했습니다.
