### PR TITLE
일정 생성 모달창 버그 해결

### DIFF
--- a/src/components/common/dropdown/DropdownController.tsx
+++ b/src/components/common/dropdown/DropdownController.tsx
@@ -13,16 +13,21 @@ const DropdownController = ({
   const newChildren = Children.map(children, (child, index) => {
     if (
       typeof child === 'object' &&
-      Object.hasOwnProperty.call(child, '$$typeof')
+      (Object.hasOwnProperty.call(child, 'type') ||
+        Object.hasOwnProperty.call(child, '$$typeof'))
     ) {
       const functionalChild = child as React.ReactElement;
       const childType = functionalChild?.type;
 
       // type 이 function 일 경우 = Functional Component
+      // render를 가지고 있으면 = Component
       // div, span과 같은 기존 DOM = string
       // React에서 사용하는 것 = symbol
       let newProps = { ...(functionalChild?.props && {}), key: index };
-      if (typeof childType === 'function') {
+      if (
+        Object.hasOwnProperty.call(childType, 'render') ||
+        typeof childType === 'function'
+      ) {
         newProps = { ...newProps, isShow };
       }
 

--- a/src/components/modal/plan/PlanCategory.tsx
+++ b/src/components/modal/plan/PlanCategory.tsx
@@ -12,7 +12,10 @@ import { MAX_CANDIDATE_LENGTH } from '@/constants';
 import { useCategoryQuery } from '@/hooks/rq/category';
 import useDebounce from '@/hooks/useDebounce';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
-import { PlanModalClassifierTitle } from '@/styles/planModal';
+import {
+  PlanModalClassifierTitle,
+  PlanModalCollapseDuration,
+} from '@/styles/planModal';
 import { ICategory } from '@/types/rq/category';
 
 // 입력과 일치하는 category 존재여부에 따라 다른 것을 보여주기 위해 정의한 타입
@@ -83,7 +86,7 @@ const PlanCategory: React.FC = () => {
   };
 
   return (
-    <Container>
+    <Container duration={PlanModalCollapseDuration}>
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="카테고리"

--- a/src/components/modal/plan/PlanDate/TimeInput.tsx
+++ b/src/components/modal/plan/PlanDate/TimeInput.tsx
@@ -61,7 +61,6 @@ const TimeInput = ({ setTime, time }: Props) => {
         onChange={(e) => setInputTime(e.target.value)}
         onKeyDown={onInputEnter}
         onBlur={onBlurHandler}
-        size={6}
       />
       {openedOptions && (
         <TimeOptionList timeInfo={timeInfo} setTime={setInputTime} />
@@ -76,6 +75,7 @@ const Input = styled.input<{ invalid?: boolean }>`
   border-radius: 5px;
   margin: 0 2px;
   text-align: center;
+  width: 86px;
   ${FONT_REGULAR_3}
   &:hover {
     background-color: ${({ theme }) => theme.background3};

--- a/src/components/modal/plan/PlanMemo.tsx
+++ b/src/components/modal/plan/PlanMemo.tsx
@@ -11,6 +11,7 @@ import {
   ClassifierAdditionalFontStyle,
   ClassifierAdditionalMarginRight,
   PlanModalClassifierTitle,
+  PlanModalCollapseDuration,
 } from '@/styles/planModal';
 
 const PlanMemo: React.FC = () => {
@@ -41,7 +42,7 @@ const PlanMemo: React.FC = () => {
   };
 
   return (
-    <Container duration={0.5}>
+    <Container duration={PlanModalCollapseDuration} defaultVisibility={true}>
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="메모"

--- a/src/components/modal/plan/PlanTag.tsx
+++ b/src/components/modal/plan/PlanTag.tsx
@@ -12,6 +12,7 @@ import {
   ClassifierAdditionalFontStyle,
   ClassifierAdditionalMarginRight,
   PlanModalClassifierTitle,
+  PlanModalCollapseDuration,
 } from '@/styles/planModal';
 
 const PlanTag: React.FC = () => {
@@ -64,7 +65,7 @@ const PlanTag: React.FC = () => {
   };
 
   return (
-    <Container>
+    <Container duration={PlanModalCollapseDuration} defaultVisibility={true}>
       <Dropdown.Controller>
         <PlanModalClassifierTitle
           title="태그"

--- a/src/components/modal/plan/index.tsx
+++ b/src/components/modal/plan/index.tsx
@@ -18,7 +18,6 @@ import { useCreatePlanMutation, useUpdatePlanMutation } from '@/hooks/rq/plan';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 type TPlanModalProps = {
-  isEdit?: boolean;
   onClose?: () => void;
   onDone?: () => void;
   openModal?: boolean;
@@ -28,19 +27,20 @@ type TPlanModal = React.FC<TPlanModalProps>;
 
 const PlanModal: TPlanModal = ({
   openModal: initOpenModal,
-  isEdit = false,
   onClose,
   onDone,
 }: TPlanModalProps) => {
-  const { focusedPlan, openModal, clearPlan, isDisabled } = useFocusedPlanState(
-    ({ focusedPlan, isDragging, clearDraggedPlan }) => ({
-      focusedPlan,
-      openModal: initOpenModal || (!isDragging && !!focusedPlan),
-      clearPlan: clearDraggedPlan,
-      isDisabled: !focusedPlan?.startTime || !focusedPlan?.endTime,
-    }),
-    shallow,
-  );
+  const { focusedPlan, openModal, clearPlan, isDisabled, isEdit } =
+    useFocusedPlanState(
+      ({ focusedPlan, isDragging, clearDraggedPlan, type }) => ({
+        focusedPlan,
+        openModal: initOpenModal || (!isDragging && !!focusedPlan),
+        clearPlan: clearDraggedPlan,
+        isDisabled: !focusedPlan?.startTime || !focusedPlan?.endTime,
+        isEdit: type === 'edit',
+      }),
+      shallow,
+    );
   const { mutateAsync: createMutate } = useCreatePlanMutation();
   const { mutateAsync: updateMutate } = useUpdatePlanMutation();
 
@@ -60,6 +60,7 @@ const PlanModal: TPlanModal = ({
         await createMutate(rest);
       }
       onDone?.();
+      clearPlan();
     } catch (e) {
       alert('일정 생성에 실패했습니다.');
     }
@@ -104,7 +105,7 @@ const Modal = styled(ModalContainer)`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 400px;
+  min-width: 400px;
   padding: 24px;
   box-shadow: 1px 10px 25px rgba(0, 0, 0, 0.25);
   border-radius: 20px;
@@ -116,4 +117,5 @@ const Hr = styled.hr`
   border: none;
   background-color: ${({ theme }) => theme.border1};
 `;
+
 export default PlanModal;

--- a/src/components/sidebar/classifier/ClassifierTitle.tsx
+++ b/src/components/sidebar/classifier/ClassifierTitle.tsx
@@ -40,7 +40,7 @@ const ClassifierTitle: React.FC<TProps> = ({
         <ChevronIcon
           width={CLASSIFIER_TITLE_ICON_SIZE}
           height={CLASSIFIER_TITLE_ICON_SIZE}
-          type={isShow ? 'down' : 'up'}
+          type={isShow ? 'up' : 'down'}
         />
       </div>
     </Container>

--- a/src/stories/modals/PlanModal.stories.tsx
+++ b/src/stories/modals/PlanModal.stories.tsx
@@ -18,6 +18,5 @@ Create.args = {
 
 export const Update = Template.bind({});
 Update.args = {
-  isEdit: true,
   openModal: true,
 };

--- a/src/styles/planModal.ts
+++ b/src/styles/planModal.ts
@@ -6,6 +6,8 @@ import { FONT_REGULAR_7 } from '@/styles/font';
 const ClassifierAdditionalMarginRight = '5px';
 const ClassifierAdditionalFontStyle = FONT_REGULAR_7;
 
+const PlanModalCollapseDuration = 0.15;
+
 const PlanModalClassifierTitle = styled(ClassifierTitle)`
   padding: 21px 0;
   margin-top: 0;
@@ -16,4 +18,5 @@ export {
   ClassifierAdditionalMarginRight,
   ClassifierAdditionalFontStyle,
   PlanModalClassifierTitle,
+  PlanModalCollapseDuration,
 };


### PR DESCRIPTION
- Closes #114 

## ✨ **구현 기능 명세**

1. ~~헤더 부분의 색상 선택 컴포넌트가 찌그러짐~~
2. 날짜 선택시 년월일이 모두 있을 경우, 레이아웃이 변형됨
3. 시각 input 컴포넌트가 시각을 모두 보여주지 못하고 일부만 보여줌
4. 수정시 버튼 문구가 '생성'으로 나타남
5. 수정시 버튼을 클릭하였을 때 수정이 아닌 새로운 일정이 생성됨
6. Dropdown의 화살표가 올바르게 동작

## 🎁 **주목할 점**

### 1번 버그

이 버그는 다른 코드로 인한 버그였으므로 해결하지 않아도 되었습니다.

### 2번 버그

이 버그는 모달창의 `width`를 `min-width`로 변경하여 해결하였습니다. 대신 선택날짜가 해가 넘어가는 경우, 년도까지 표시해주어야 하므로 너비가 min-width 보다 길어집니다. 이 때 모달창이 처음보다 뚱뚱해집니다.

### 3번 버그

input 태그에 size가 아니라 css로 width를 지정해줌으로써 해결하였습니다.

### 4번 & 5번 버그

PlanModal의 isEdit을 props가 아닌 zustand의 store에 저장되어있던 `type`을 통해 가져오도록 변경하여 해결하였습니다.

### 6번 버그

DropdownController의 조건문을 다음과 같이 수정하여 해결하였습니다.

```ts
    if (
      typeof child === 'object' &&
      (Object.hasOwnProperty.call(child, 'type') ||  // 추가
        Object.hasOwnProperty.call(child, '$$typeof'))
    ) {
       ...
       if (
        Object.hasOwnProperty.call(childType, 'render') || // 추가
        typeof childType === 'function'
      ) {
          ...
      }

      ...
```

## 🌄 **스크린샷**

![modal-bug](https://github.com/JiPyoTak/plandar-client/assets/32933980/841b0b7f-50ae-4479-8cc0-f257e519c6c2)
