### PR TITLE
일정에 따라 Sidebar 렌더링 및 컨트롤 활성화

### DIFF
--- a/src/components/calendars/large/CalendarView.tsx
+++ b/src/components/calendars/large/CalendarView.tsx
@@ -7,13 +7,11 @@ import moment from 'moment';
 import CalendarLayer from './CalendarLayer';
 import CalendarOverlay from './CalendarOverlay';
 import CalendarWeek from './CalendarWeek';
-import { useGetPlansQuery } from '@/hooks/rq/plan';
+import useClassifiedPlans from '@/hooks/useClassifiedPlans';
 import usePlanDrag from '@/hooks/usePlanDrag';
 import useDateState from '@/stores/date';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import { getCalendarInfo } from '@/utils/calendar/getCalendarInfo';
-import { getFormattedDate } from '@/utils/date/getFormattedDate';
-import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 import { getDaysPlanManager } from '@/utils/plan/getDaysPlanManager';
 
 const CalendarView = () => {
@@ -26,14 +24,7 @@ const CalendarView = () => {
     [year, month, day],
   );
 
-  const { startFormat, endFormat } = getFormattedDate(
-    ...getStartAndEndDate({ year, month, day }),
-  );
-
-  const { data } = useGetPlansQuery({
-    timemin: startFormat,
-    timemax: endFormat,
-  });
+  const data = useClassifiedPlans();
 
   const planManagers = useMemo(() => {
     const plans = (data ?? []).filter((plan) => plan.id !== focusedPlan?.id);

--- a/src/components/sidebar/CategoryClassifier.tsx
+++ b/src/components/sidebar/CategoryClassifier.tsx
@@ -20,7 +20,7 @@ import useCategoryClassifierState from '@/stores/classifier/category';
 import { TColor } from '@/types';
 
 const CategoryClassifier: React.FC = () => {
-  const { data: categoryData, isLoading } = useCategoryQuery();
+  const { data: categoryData } = useCategoryQuery();
   const { mutate: categoryCreate } = useCategoryCreate();
   const { mutate: categoryUpdate } = useCategoryUpdate();
   const [modalState, setModalState] = useState<TCategoryModalProps | null>(
@@ -70,8 +70,6 @@ const CategoryClassifier: React.FC = () => {
       },
     });
   };
-
-  if (isLoading) return null;
 
   return (
     <>

--- a/src/components/sidebar/TagClassifier.tsx
+++ b/src/components/sidebar/TagClassifier.tsx
@@ -45,7 +45,6 @@ const TagClassifier: React.FC = () => {
           key={title}
           onClick={() => toggleTagShow(title)}
           isActive={!hiddenTags.has(title)}
-          onEdit={() => undefined}
           text={title}
         />
       ))}

--- a/src/components/sidebar/TagClassifier.tsx
+++ b/src/components/sidebar/TagClassifier.tsx
@@ -1,29 +1,50 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 
 import Dropdown from '../common/dropdown';
 
 import ClassifierItem from '@/components/sidebar/classifier/ClassifierItem';
 import ClassifierTitle from '@/components/sidebar/classifier/ClassifierTitle';
+import { useGetPlansQuery } from '@/hooks/rq/plan';
 import useTagClassifierState from '@/stores/classifier/tag';
+import useDateState from '@/stores/date';
+import { getFormattedDate } from '@/utils/date/getFormattedDate';
+import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 
 const TagClassifier: React.FC = () => {
-  const [testTags] = useState([
-    { id: 1, title: '테스트1' },
-    { id: 2, title: '테스트2' },
-  ]);
-
   const { hiddenTags, toggleTagShow } = useTagClassifierState();
+
+  const { year, month, day } = useDateState();
+  const { startFormat, endFormat } = getFormattedDate(
+    ...getStartAndEndDate({ year, month, day }),
+  );
+
+  const { data } = useGetPlansQuery({
+    timemin: startFormat,
+    timemax: endFormat,
+  });
+
+  const tags = useMemo(() => {
+    const tagNameSet = new Set<string>();
+
+    for (const { tags } of data ?? []) {
+      for (const tag of tags ?? []) {
+        tagNameSet.add(tag);
+      }
+    }
+
+    return [...tagNameSet].sort();
+  }, [data]);
 
   return (
     <Dropdown>
       <Dropdown.Controller>
         <ClassifierTitle title={'태그'} />
       </Dropdown.Controller>
-      {testTags.map(({ id, title }) => (
+      {tags.map((title) => (
         <ClassifierItem
-          key={id}
-          onClick={() => toggleTagShow(id)}
-          isActive={!hiddenTags.has(id)}
+          key={title}
+          onClick={() => toggleTagShow(title)}
+          isActive={!hiddenTags.has(title)}
           onEdit={() => undefined}
           text={title}
         />

--- a/src/components/sidebar/TagClassifier.tsx
+++ b/src/components/sidebar/TagClassifier.tsx
@@ -18,7 +18,7 @@ const TagClassifier: React.FC = () => {
     ...getStartAndEndDate({ year, month, day }),
   );
 
-  const { data } = useGetPlansQuery({
+  const { data: planData } = useGetPlansQuery({
     timemin: startFormat,
     timemax: endFormat,
   });
@@ -26,14 +26,14 @@ const TagClassifier: React.FC = () => {
   const tags = useMemo(() => {
     const tagNameSet = new Set<string>();
 
-    for (const { tags } of data ?? []) {
+    for (const { tags } of planData ?? []) {
       for (const tag of tags ?? []) {
         tagNameSet.add(tag);
       }
     }
 
     return [...tagNameSet].sort();
-  }, [data]);
+  }, [planData]);
 
   return (
     <Dropdown>

--- a/src/components/sidebar/TypeClassifier.tsx
+++ b/src/components/sidebar/TypeClassifier.tsx
@@ -10,8 +10,14 @@ import useTypeClassifierState from '@/stores/classifier/type';
 const TypeClassifier: React.FC = () => {
   const theme = useTheme();
 
-  const { type, toggleEventShow, toggleTaskShow, toggleAlarmShow } =
-    useTypeClassifierState();
+  const {
+    showEvent,
+    showTask,
+    showAlarm,
+    toggleEventShow,
+    toggleTaskShow,
+    toggleAlarmShow,
+  } = useTypeClassifierState();
 
   return (
     <Dropdown>
@@ -20,19 +26,19 @@ const TypeClassifier: React.FC = () => {
       </Dropdown.Controller>
       <ClassifierItem
         onClick={toggleEventShow}
-        isActive={type.showEvent}
+        isActive={showEvent}
         text={'기념일'}
         color={theme.orange}
       />
       <ClassifierItem
         onClick={toggleTaskShow}
-        isActive={type.showTask}
+        isActive={showTask}
         text={'할 일'}
         color={theme.blue}
       />
       <ClassifierItem
         onClick={toggleAlarmShow}
-        isActive={type.showAlarm}
+        isActive={showAlarm}
         text={'알림'}
         color={theme.red}
       />

--- a/src/components/sidebar/classifier/ClassifierItem.tsx
+++ b/src/components/sidebar/classifier/ClassifierItem.tsx
@@ -25,6 +25,11 @@ const ClassifierItem: React.FC<TProps> = ({
 }) => {
   const theme = useTheme();
 
+  const onPencilEdit: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.stopPropagation();
+    onEdit?.();
+  };
+
   return (
     <Wrapper {...restProps}>
       <CircleDiv
@@ -36,7 +41,7 @@ const ClassifierItem: React.FC<TProps> = ({
       </CircleDiv>
       <span css={{ flex: 1 }}>{text}</span>
       {onEdit && (
-        <button onClick={onEdit}>
+        <button onClick={onPencilEdit}>
           <PencilIcon
             className={CLASSIFIER_EDITABLE_ITEM_CLASS}
             width={20}

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import CategoryClassifier from './CategoryClassifier';
 import SmallCalendar from './SmallCalendar';
 import TagClassifier from './TagClassifier';
-import TypeClassifier from './TypeClassifier';
 import useDrawerState from '@/stores/drawer';
 import { SIDEBAR_WIDTH } from '@/styles/home';
 
@@ -16,7 +15,10 @@ const SideBar: React.FC = () => {
     <Container css={{ width: isOpened ? SIDEBAR_WIDTH : 0 }}>
       <InnerContainer>
         <SmallCalendar />
+        {/*         
+        Type 구현이 완료된 후 사용 할 것
         <TypeClassifier />
+        */}
         <CategoryClassifier />
         <TagClassifier />
       </InnerContainer>

--- a/src/components/timetable/view/index.tsx
+++ b/src/components/timetable/view/index.tsx
@@ -5,11 +5,8 @@ import { Moment } from 'moment';
 
 import TimetableColumns from './columns';
 import TimetableAllDay from './TimetableAllDay';
-import { useGetPlansQuery } from '@/hooks/rq/plan';
+import useClassifiedPlans from '@/hooks/useClassifiedPlans';
 import usePlanDrag from '@/hooks/usePlanDrag';
-import useDateState from '@/stores/date';
-import { getFormattedDate } from '@/utils/date/getFormattedDate';
-import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 import { divideTimePlans } from '@/utils/plan/divideTimePlans';
 
 type TProps = {
@@ -19,16 +16,7 @@ type TProps = {
 const TimetableView: React.FC<TProps> = ({ dateMoments }) => {
   const { onMouseMove, changeCurrentDate } = usePlanDrag();
 
-  const { year, month, day } = useDateState();
-  const { startFormat, endFormat } = getFormattedDate(
-    ...getStartAndEndDate({ year, month, day }),
-  );
-  const { data: plans } = useGetPlansQuery({
-    timemin: startFormat,
-    timemax: endFormat,
-  });
-
-  // 종일, 시간에 들어가야 할 일정 분류하기
+  const plans = useClassifiedPlans();
   const { timePlans, allDayPlans } = divideTimePlans(plans ?? []);
 
   return (

--- a/src/hooks/useClassifiedPlans.ts
+++ b/src/hooks/useClassifiedPlans.ts
@@ -1,0 +1,49 @@
+import { useGetPlansQuery } from '@/hooks/rq/plan';
+import useCategoryClassifierState from '@/stores/classifier/category';
+import useTagClassifierState from '@/stores/classifier/tag';
+import useTypeClassifierState from '@/stores/classifier/type';
+import useDateState from '@/stores/date';
+import { IPlan } from '@/types/rq/plan';
+import { getFormattedDate } from '@/utils/date/getFormattedDate';
+import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
+
+const useClassifiedPlans = () => {
+  const hiddenCategories = useCategoryClassifierState(
+    (state) => state.hiddenCategories,
+  );
+  const hiddenTags = useTagClassifierState((state) => state.hiddenTags);
+  const { showAlarm, showEvent, showTask } = useTypeClassifierState(
+    ({ showAlarm, showEvent, showTask }) => ({
+      showAlarm,
+      showEvent,
+      showTask,
+    }),
+  );
+
+  const { year, month, day } = useDateState();
+  const { startFormat, endFormat } = getFormattedDate(
+    ...getStartAndEndDate({ year, month, day }),
+  );
+
+  const { data: plans } = useGetPlansQuery({
+    timemin: startFormat,
+    timemax: endFormat,
+  });
+
+  const classifiedPlans = (plans ?? []).reduce((result, plan) => {
+    const { categoryId, tags } = plan;
+
+    if (categoryId && hiddenCategories.has(categoryId)) return result;
+    if (tags.some((tag) => hiddenTags.has(tag))) return result;
+    if (!showAlarm && plan.type === 'alarm') return result;
+    if (!showEvent && plan.type === 'event') return result;
+    if (!showTask && plan.type === 'task') return result;
+
+    result.push(plan);
+    return result;
+  }, [] as IPlan[]);
+
+  return classifiedPlans;
+};
+
+export default useClassifiedPlans;

--- a/src/hooks/useClassifiedPlans.ts
+++ b/src/hooks/useClassifiedPlans.ts
@@ -34,7 +34,7 @@ const useClassifiedPlans = () => {
     const { categoryId, tags } = plan;
 
     if (categoryId && hiddenCategories.has(categoryId)) return result;
-    if (tags.some((tag) => hiddenTags.has(tag))) return result;
+    if (tags.every((tag) => hiddenTags.has(tag))) return result;
     if (!showAlarm && plan.type === 'alarm') return result;
     if (!showEvent && plan.type === 'event') return result;
     if (!showTask && plan.type === 'task') return result;

--- a/src/stores/classifier/tag.ts
+++ b/src/stores/classifier/tag.ts
@@ -1,21 +1,21 @@
 import { create } from 'zustand';
 
 interface ITagClassifierState {
-  hiddenTags: Set<number>;
+  hiddenTags: Set<string>;
 
-  toggleTagShow: (tagId: number) => void;
+  toggleTagShow: (tagId: string) => void;
 
   reset: () => void;
 }
 
 const initialState = {
-  hiddenTags: new Set<number>(),
+  hiddenTags: new Set<string>(),
 } as const;
 
 const useTagClassifierState = create<ITagClassifierState>((set) => ({
   ...initialState,
 
-  toggleTagShow: (tagId: number) =>
+  toggleTagShow: (tagId: string) =>
     set((state) => {
       const newHiddenTags = new Set(state.hiddenTags);
       if (newHiddenTags.has(tagId)) newHiddenTags.delete(tagId);

--- a/src/stores/classifier/type.ts
+++ b/src/stores/classifier/type.ts
@@ -1,12 +1,9 @@
 import { create } from 'zustand';
 
 interface ITypeClassifierState {
-  type: {
-    showEvent: boolean;
-    showTask: boolean;
-    showAlarm: boolean;
-  };
-
+  showEvent: boolean;
+  showTask: boolean;
+  showAlarm: boolean;
   toggleEventShow: () => void;
   toggleTaskShow: () => void;
   toggleAlarmShow: () => void;
@@ -15,11 +12,9 @@ interface ITypeClassifierState {
 }
 
 const initialState = {
-  type: {
-    showEvent: true,
-    showTask: true,
-    showAlarm: true,
-  },
+  showEvent: true,
+  showTask: true,
+  showAlarm: true,
 } as const;
 
 const useTypeClassifierState = create<ITypeClassifierState>((set) => ({
@@ -27,15 +22,15 @@ const useTypeClassifierState = create<ITypeClassifierState>((set) => ({
 
   toggleEventShow: () =>
     set((state) => ({
-      type: { ...state.type, showEvent: !state.type.showEvent },
+      showEvent: !state.showEvent,
     })),
   toggleTaskShow: () =>
     set((state) => ({
-      type: { ...state.type, showTask: !state.type.showTask },
+      showTask: !state.showTask,
     })),
   toggleAlarmShow: () =>
     set((state) => ({
-      type: { ...state.type, showAlarm: !state.type.showAlarm },
+      showAlarm: !state.showAlarm,
     })),
 
   reset: () => set({ ...initialState }),

--- a/src/stories/apis/category.ts
+++ b/src/stories/apis/category.ts
@@ -1,0 +1,42 @@
+import { serverAPI } from './msw';
+import categoryStubManager from '@/stories/apis/data/category';
+
+const getCategoryAPIHandler = serverAPI.get(`/category`, (req, res, ctx) => {
+  const data = categoryStubManager.get();
+  return res(ctx.status(200), ctx.json({ data, success: true }));
+});
+
+const createCategoryAPIHandler = serverAPI.post(
+  `/category`,
+  async (req, res, ctx) => {
+    const categoryData = await req.json();
+    const category = categoryStubManager.add(categoryData);
+
+    return res(ctx.status(201), ctx.json({ data: category, success: true }));
+  },
+);
+
+const updateCategoryAPIHandler = serverAPI.put(
+  `/category/:id`,
+  async (req, res, ctx) => {
+    const id = Number(req.params?.id);
+
+    if (isNaN(id)) {
+      return res(
+        ctx.status(400),
+        ctx.json({ success: false, message: '잘못된 id 입니다' }),
+      );
+    }
+
+    const categoryData = await req.json();
+    const category = categoryStubManager.update(categoryData);
+
+    return res(ctx.status(200), ctx.json({ data: category, success: true }));
+  },
+);
+
+export {
+  getCategoryAPIHandler,
+  createCategoryAPIHandler,
+  updateCategoryAPIHandler,
+};

--- a/src/stories/apis/data/category.ts
+++ b/src/stories/apis/data/category.ts
@@ -1,0 +1,42 @@
+import StubManager from '@/stories/apis/data';
+import { theme } from '@/styles/theme';
+import { ICategory } from '@/types/rq/category';
+
+const initialCategories = [
+  {
+    id: 1,
+    name: '카테고리1',
+    color: theme.primary,
+  },
+] as const;
+
+class CategoryStubManager extends StubManager<ICategory> {
+  private static instance: CategoryStubManager;
+  constructor(initialCategoryArray?: ICategory[]) {
+    if (CategoryStubManager.instance) {
+      return CategoryStubManager.instance;
+    }
+
+    super(initialCategoryArray);
+    CategoryStubManager.instance = this;
+  }
+
+  public createStub({ ...categoryData }: Partial<ICategory>): ICategory {
+    if (isNaN(Number(categoryData?.id))) {
+      ++this.id;
+    }
+
+    const categoryStub = {
+      id: this.id,
+      name: `카테고리 ${this.id}`,
+      color: theme.primary,
+      ...categoryData,
+    };
+
+    return categoryStub;
+  }
+}
+
+const categoryStubManager = new CategoryStubManager([...initialCategories]);
+
+export default categoryStubManager;

--- a/src/stories/apis/data/category.ts
+++ b/src/stories/apis/data/category.ts
@@ -1,4 +1,5 @@
 import StubManager from '@/stories/apis/data';
+import createRandomColor from '@/stories/utils/createRandomColor';
 import { theme } from '@/styles/theme';
 import { ICategory } from '@/types/rq/category';
 
@@ -21,7 +22,7 @@ class CategoryStubManager extends StubManager<ICategory> {
     CategoryStubManager.instance = this;
   }
 
-  public createStub({ ...categoryData }: Partial<ICategory>): ICategory {
+  public createStub({ ...categoryData }: Partial<ICategory> = {}): ICategory {
     if (isNaN(Number(categoryData?.id))) {
       ++this.id;
     }
@@ -29,7 +30,7 @@ class CategoryStubManager extends StubManager<ICategory> {
     const categoryStub = {
       id: this.id,
       name: `카테고리 ${this.id}`,
-      color: theme.primary,
+      color: createRandomColor(),
       ...categoryData,
     };
 

--- a/src/stories/apis/data/index.ts
+++ b/src/stories/apis/data/index.ts
@@ -58,8 +58,12 @@ class StubManager<Data extends { id: number }> {
   }
 
   public clear() {
-    this.id = 0;
+    this.id = this.initialDataArray.length;
     this.data = [...this.initialDataArray];
+  }
+
+  public getId() {
+    return this.id;
   }
 }
 

--- a/src/stories/apis/data/index.ts
+++ b/src/stories/apis/data/index.ts
@@ -1,0 +1,66 @@
+class StubManager<Data extends { id: number }> {
+  protected id: number;
+  protected data: Data[];
+  protected initialDataArray: Data[];
+
+  public constructor(initialDataArray: Data[] = []) {
+    this.id = initialDataArray.length;
+    this.data = [...initialDataArray];
+    this.initialDataArray = [...initialDataArray];
+  }
+
+  public createStub({ ...data }: Partial<Data>): Data {
+    if (isNaN(Number(data?.id))) {
+      ++this.id;
+    }
+
+    return {
+      id: this.id,
+      ...data,
+    } as Data;
+  }
+
+  public get() {
+    return [...this.data];
+  }
+
+  public add(...args: Parameters<this['createStub']>) {
+    const data = this.createStub.call(this, ...args);
+    this.data.push(data);
+    return data;
+  }
+
+  public update(data: Partial<Data> & { id: number }) {
+    const target = this.data.find(({ id }) => id === data?.id);
+
+    if (!target) throw Error('Stub Manager : update failed');
+
+    Object.keys(data).forEach((key) => {
+      if (Object.hasOwnProperty.call(target, key)) {
+        Object.defineProperty(target, key, {
+          value: data[key as keyof typeof data],
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        });
+      }
+    });
+
+    return target;
+  }
+
+  public delete(dataId: number) {
+    const index = this.data.findIndex(({ id }) => id === dataId);
+
+    if (index === -1) throw Error('Stub Manager : delete failed');
+
+    return this.data.splice(index, 1)[0];
+  }
+
+  public clear() {
+    this.id = 0;
+    this.data = [...this.initialDataArray];
+  }
+}
+
+export default StubManager;

--- a/src/stories/apis/data/plan.ts
+++ b/src/stories/apis/data/plan.ts
@@ -2,14 +2,8 @@ import moment, { MomentInput } from 'moment';
 
 import Plan from '@/plan/Plan';
 import StubManager from '@/stories/apis/data';
-import { TColor } from '@/types';
+import createRandomColor from '@/stories/utils/createRandomColor';
 import { IPlan } from '@/types/rq/plan';
-
-const createRandomColor = () => {
-  return `#${Math.round(Math.random() * 0xffffff)
-    .toString(16)
-    .padStart(6, '0')}` as TColor;
-};
 
 class PlanStubManager extends StubManager<Plan> {
   private static instance: PlanStubManager;

--- a/src/stories/apis/data/plan.ts
+++ b/src/stories/apis/data/plan.ts
@@ -1,6 +1,7 @@
 import moment, { MomentInput } from 'moment';
 
 import Plan from '@/plan/Plan';
+import StubManager from '@/stories/apis/data';
 import { TColor } from '@/types';
 import { IPlan } from '@/types/rq/plan';
 
@@ -10,21 +11,15 @@ const createRandomColor = () => {
     .padStart(6, '0')}` as TColor;
 };
 
-class PlanStubManager {
-  private data: Plan[];
-  private id: number;
-
-  // Use Singleton Pattern
+class PlanStubManager extends StubManager<Plan> {
   private static instance: PlanStubManager;
-  private constructor() {
-    this.data = [];
-    this.id = 0;
-  }
-  public static getInstance() {
-    if (!PlanStubManager.instance) {
-      PlanStubManager.instance = new PlanStubManager();
+  constructor() {
+    if (PlanStubManager.instance) {
+      return PlanStubManager.instance;
     }
-    return PlanStubManager.instance;
+
+    super();
+    PlanStubManager.instance = this;
   }
 
   public createStub({
@@ -59,7 +54,14 @@ class PlanStubManager {
     return mockedPlan;
   }
 
-  public get({ timeMin, timeMax }: { timeMin: string; timeMax: string }) {
+  public get(): Plan[];
+  public get(query: { timeMin: string; timeMax: string }): Plan[];
+  public get(query?: { timeMin: string; timeMax: string }) {
+    if (!query) {
+      return this.get();
+    }
+
+    const { timeMin, timeMax } = query;
     const st = moment(timeMin);
     const et = moment(timeMax);
 
@@ -74,48 +76,8 @@ class PlanStubManager {
       return isStartBetween || isEndBetween || isTimeBigger;
     });
   }
-
-  public add(...args: Parameters<PlanStubManager['createStub']>) {
-    const plan = this.createStub(...args);
-    this.data.push(plan);
-    return plan;
-  }
-
-  public update(planData: Partial<IPlan> & { id: number }) {
-    const target = this.data.find(({ id }) => id === planData?.id);
-
-    if (!target) throw Error('Plan Stub : update failed');
-
-    Object.keys(planData).forEach((key) => {
-      if (Object.hasOwnProperty.call(target, key)) {
-        Object.defineProperty(target, key, {
-          value: planData[key as keyof typeof planData],
-          configurable: true,
-          enumerable: true,
-          writable: true,
-        });
-      }
-    });
-
-    return target;
-  }
-
-  public delete(planId: number) {
-    const index = this.data.findIndex(({ id }) => id === planId);
-
-    if (index === -1) throw Error('Plan Stub : delete failed');
-
-    return this.data.splice(index, 1)[0];
-  }
-
-  public clear() {
-    this.id = 0;
-    for (let i = this.data.length; i >= 0; i--) {
-      delete this.data[i];
-    }
-  }
 }
 
-const planStubManager = PlanStubManager.getInstance();
+const planStubManager = new PlanStubManager();
 
 export default planStubManager;

--- a/src/stories/apis/data/plan.ts
+++ b/src/stories/apis/data/plan.ts
@@ -23,7 +23,7 @@ class PlanStubManager extends StubManager<Plan> {
   }: Omit<Partial<IPlan>, 'startTime' | 'endTime'> & {
     startTime?: MomentInput;
     endTime?: MomentInput;
-  }) {
+  } = {}) {
     if (isNaN(Number(planData?.id))) {
       ++this.id;
     }

--- a/src/stories/apis/data/plan.ts
+++ b/src/stories/apis/data/plan.ts
@@ -52,7 +52,7 @@ class PlanStubManager extends StubManager<Plan> {
   public get(query: { timeMin: string; timeMax: string }): Plan[];
   public get(query?: { timeMin: string; timeMax: string }) {
     if (!query) {
-      return this.get();
+      return super.get();
     }
 
     const { timeMin, timeMax } = query;

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -3,12 +3,15 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CategoryClassifier from '@/components/sidebar/CategoryClassifier';
 import { useCategoryCreate } from '@/hooks/rq/category';
+import { useCreatePlanMutation } from '@/hooks/rq/plan';
 import {
   createCategoryAPIHandler,
   getCategoryAPIHandler,
   updateCategoryAPIHandler,
 } from '@/stories/apis/category';
 import categoryStubManager from '@/stories/apis/data/category';
+import planStubManager from '@/stories/apis/data/plan';
+import { createPlanApiHandler } from '@/stories/apis/plan';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -16,16 +19,28 @@ export default {
 } as ComponentMeta<typeof CategoryClassifier>;
 
 const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
-  const { mutateAsync } = useCategoryCreate();
+  const { mutateAsync: createCategoryMutateAsync } = useCategoryCreate();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
 
   const createCategory = () => {
-    mutateAsync(categoryStubManager.createStub());
+    createCategoryMutateAsync(categoryStubManager.createStub());
+  };
+
+  const createPlan = () => {
+    const maxId = categoryStubManager.getId();
+    if (maxId === 0) return;
+
+    const randomId = Math.round(Math.random() * maxId);
+    createPlanMutateAsync(planStubManager.createStub({ categoryId: randomId }));
   };
 
   return (
     <div>
       <Controls>
         <TestButton onClick={createCategory}>카테고리 추가하기</TestButton>
+        <TestButton onClick={createPlan}>
+          랜덤 카테고리 일정 생성하기
+        </TestButton>
       </Controls>
       <CategoryClassifier {...args} />
     </div>
@@ -53,6 +68,7 @@ Category.parameters = {
       getCategoryAPIHandler,
       createCategoryAPIHandler,
       updateCategoryAPIHandler,
+      createPlanApiHandler,
     ],
   },
 };

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -1,11 +1,14 @@
+import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CategoryClassifier from '@/components/sidebar/CategoryClassifier';
+import { useCategoryCreate } from '@/hooks/rq/category';
 import {
   createCategoryAPIHandler,
   getCategoryAPIHandler,
   updateCategoryAPIHandler,
 } from '@/stories/apis/category';
+import categoryStubManager from '@/stories/apis/data/category';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -13,8 +16,34 @@ export default {
 } as ComponentMeta<typeof CategoryClassifier>;
 
 const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
-  return <CategoryClassifier {...args} />;
+  const { mutateAsync } = useCategoryCreate();
+
+  const createCategory = () => {
+    mutateAsync(categoryStubManager.createStub());
+  };
+
+  return (
+    <div>
+      <Controls>
+        <TestButton onClick={createCategory}>카테고리 추가하기</TestButton>
+      </Controls>
+      <CategoryClassifier {...args} />
+    </div>
+  );
 };
+
+const Controls = styled.div`
+  padding: 1rem;
+
+  display: flex;
+  column-gap: 1rem;
+`;
+
+const TestButton = styled.button`
+  padding: 0.5rem;
+  border: 1px solid black;
+  border-radius: 8px;
+`;
 
 export const Category = Template.bind({});
 Category.args = {};

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -2,8 +2,10 @@ import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CategoryClassifier from '@/components/sidebar/CategoryClassifier';
-import { useCategoryCreate } from '@/hooks/rq/category';
+import { useCategoryCreate, useCategoryQuery } from '@/hooks/rq/category';
 import { useCreatePlanMutation } from '@/hooks/rq/plan';
+import useClassifiedPlans from '@/hooks/useClassifiedPlans';
+import useDateState from '@/stores/date';
 import {
   createCategoryAPIHandler,
   getCategoryAPIHandler,
@@ -11,7 +13,8 @@ import {
 } from '@/stories/apis/category';
 import categoryStubManager from '@/stories/apis/data/category';
 import planStubManager from '@/stories/apis/data/plan';
-import { createPlanApiHandler } from '@/stories/apis/plan';
+import { createPlanApiHandler, getPlansApiHandler } from '@/stories/apis/plan';
+import { TIMETABLE_SCROLL_STYLE } from '@/styles/timetable';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -19,6 +22,8 @@ export default {
 } as ComponentMeta<typeof CategoryClassifier>;
 
 const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
+  const { year, month } = useDateState();
+  const plans = useClassifiedPlans();
   const { mutateAsync: createCategoryMutateAsync } = useCategoryCreate();
   const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
 
@@ -30,28 +35,95 @@ const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
     const maxId = categoryStubManager.getId();
     if (maxId === 0) return;
 
-    const randomId = Math.round(Math.random() * maxId);
+    const randomId = Math.round(Math.random() * (maxId - 1)) + 1;
     createPlanMutateAsync(planStubManager.createStub({ categoryId: randomId }));
   };
 
+  const { data } = useCategoryQuery();
+  const categories = data ?? [];
+  const categoryNames = categories.reduce(
+    (names, { id, name }) => names.set(id, name),
+    new Map<number, string>(),
+  );
+  const initialCategoryPlans = categories.reduce(
+    (object, { name }) => ({ ...object, [name]: 0 }),
+    {} as { [key: string]: number },
+  );
+  const categoryPlans = plans.reduce((result, plan) => {
+    const categoryName = categoryNames.get(plan?.categoryId ?? 0);
+
+    if (categoryName) {
+      result[categoryName]++;
+    }
+
+    return result;
+  }, initialCategoryPlans);
+
   return (
-    <div>
-      <Controls>
+    <Container>
+      <div className="category-classifier-plans">
+        <h4>
+          {year}년 {month}월 일정 렌더링
+        </h4>
+        <PlanSummary>
+          <div>총 {plans.length} 개의 일정</div>
+          {Object.entries(categoryPlans).map(([name, count]) => {
+            return (
+              <div>
+                {name}({count}개)
+              </div>
+            );
+          })}
+        </PlanSummary>
+      </div>
+      <div className="category-classifier-controls">
         <TestButton onClick={createCategory}>카테고리 추가하기</TestButton>
         <TestButton onClick={createPlan}>
           랜덤 카테고리 일정 생성하기
         </TestButton>
-      </Controls>
-      <CategoryClassifier {...args} />
-    </div>
+      </div>
+      <div className="category-classifier-main">
+        <CategoryClassifier {...args} />
+      </div>
+    </Container>
   );
 };
 
-const Controls = styled.div`
-  padding: 1rem;
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
 
   display: flex;
+  flex-direction: column;
+
+  .category-classifier-controls {
+    flex: 0;
+    padding: 1rem;
+
+    display: flex;
+    column-gap: 1rem;
+  }
+
+  .category-classifier-plans {
+    width: 100%;
+    flex: 0;
+    padding: 0 1rem;
+  }
+
+  .category-classifier-main {
+    flex: 1 0 0;
+  }
+`;
+
+const PlanSummary = styled.div`
+  ${TIMETABLE_SCROLL_STYLE}
+
+  padding-top: 1rem;
+  display: flex;
   column-gap: 1rem;
+
+  overflow-x: scroll;
+  overflow-y: hidden;
 `;
 
 const TestButton = styled.button`
@@ -69,6 +141,7 @@ Category.parameters = {
       createCategoryAPIHandler,
       updateCategoryAPIHandler,
       createPlanApiHandler,
+      getPlansApiHandler,
     ],
   },
 };

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import CategoryClassifier from '@/components/sidebar/CategoryClassifier';
+
+export default {
+  title: 'Sidebar/Classifier',
+  component: CategoryClassifier,
+} as ComponentMeta<typeof CategoryClassifier>;
+
+const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
+  return <CategoryClassifier {...args} />;
+};
+
+export const Category = Template.bind({});
+Category.args = {};

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -1,6 +1,11 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import CategoryClassifier from '@/components/sidebar/CategoryClassifier';
+import {
+  createCategoryAPIHandler,
+  getCategoryAPIHandler,
+  updateCategoryAPIHandler,
+} from '@/stories/apis/category';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -13,3 +18,12 @@ const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
 
 export const Category = Template.bind({});
 Category.args = {};
+Category.parameters = {
+  msw: {
+    handlers: [
+      getCategoryAPIHandler,
+      createCategoryAPIHandler,
+      updateCategoryAPIHandler,
+    ],
+  },
+};

--- a/src/stories/sidebar/TagClassifier.stories.tsx
+++ b/src/stories/sidebar/TagClassifier.stories.tsx
@@ -1,7 +1,13 @@
+import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import TagClassifier from '@/components/sidebar/TagClassifier';
-import { getPlansApiHandler } from '@/stories/apis/plan';
+import { useCreatePlanMutation } from '@/hooks/rq/plan';
+import useClassifiedPlans from '@/hooks/useClassifiedPlans';
+import useDateState from '@/stores/date';
+import planStubManager from '@/stories/apis/data/plan';
+import { createPlanApiHandler, getPlansApiHandler } from '@/stories/apis/plan';
+import { TIMETABLE_SCROLL_STYLE } from '@/styles/timetable';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -9,13 +15,105 @@ export default {
 } as ComponentMeta<typeof TagClassifier>;
 
 const Template: ComponentStory<typeof TagClassifier> = (args) => {
-  return <TagClassifier {...args} />;
+  const { year, month } = useDateState();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const plans = useClassifiedPlans();
+
+  const tagPlans: { [key: string]: number } = {};
+  plans.forEach(({ tags }) => {
+    tags.forEach((tag) => {
+      if (!Object.hasOwnProperty.call(tagPlans, tag)) tagPlans[tag] = 0;
+      tagPlans[tag]++;
+    });
+  });
+
+  const createRandomTagPlan = () => {
+    const alphabetCount = 26;
+    const randomAlphabet = String.fromCharCode(
+      Math.round(Math.random() * alphabetCount) + 'A'.charCodeAt(0),
+    );
+
+    createPlanMutateAsync(
+      planStubManager.createStub({ tags: [randomAlphabet] }),
+    );
+  };
+
+  return (
+    <Container>
+      <div className="category-classifier-plans">
+        <h4>
+          {year}년 {month}월 일정 렌더링
+        </h4>
+        <PlanSummary>
+          <div>총 {plans.length} 개의 일정</div>
+          {Object.entries(tagPlans).map(([name, count]) => {
+            return (
+              <div>
+                {name}({count}개)
+              </div>
+            );
+          })}
+        </PlanSummary>
+      </div>
+      <div className="category-classifier-controls">
+        <TestButton onClick={createRandomTagPlan}>
+          랜덤 태그 일정 추가하기
+        </TestButton>
+      </div>
+      <div className="category-classifier-main">
+        <TagClassifier {...args} />
+      </div>
+    </Container>
+  );
 };
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  .category-classifier-controls {
+    flex: 0;
+    padding: 1rem;
+
+    display: flex;
+    column-gap: 1rem;
+  }
+
+  .category-classifier-plans {
+    width: 100%;
+    flex: 0;
+    padding: 0 1rem;
+  }
+
+  .category-classifier-main {
+    flex: 1 0 0;
+  }
+`;
+
+const PlanSummary = styled.div`
+  ${TIMETABLE_SCROLL_STYLE}
+
+  padding-top: 1rem;
+  display: flex;
+  column-gap: 1rem;
+
+  overflow-x: scroll;
+  overflow-y: hidden;
+`;
+
+const TestButton = styled.button`
+  padding: 0.5rem;
+  border: 1px solid black;
+  border-radius: 8px;
+`;
 
 export const Tag = Template.bind({});
 Tag.args = {};
 Tag.parameters = {
   msw: {
-    handlers: [getPlansApiHandler],
+    handlers: [getPlansApiHandler, createPlanApiHandler],
   },
 };

--- a/src/stories/sidebar/TagClassifier.stories.tsx
+++ b/src/stories/sidebar/TagClassifier.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import TagClassifier from '@/components/sidebar/TagClassifier';
+
+export default {
+  title: 'Sidebar/Classifier',
+  component: TagClassifier,
+} as ComponentMeta<typeof TagClassifier>;
+
+const Template: ComponentStory<typeof TagClassifier> = (args) => {
+  return <TagClassifier {...args} />;
+};
+
+export const Tag = Template.bind({});
+Tag.args = {};

--- a/src/stories/sidebar/TagClassifier.stories.tsx
+++ b/src/stories/sidebar/TagClassifier.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import TagClassifier from '@/components/sidebar/TagClassifier';
+import { getPlansApiHandler } from '@/stories/apis/plan';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -13,3 +14,8 @@ const Template: ComponentStory<typeof TagClassifier> = (args) => {
 
 export const Tag = Template.bind({});
 Tag.args = {};
+Tag.parameters = {
+  msw: {
+    handlers: [getPlansApiHandler],
+  },
+};

--- a/src/stories/sidebar/TypeClassifier.stories.tsx
+++ b/src/stories/sidebar/TypeClassifier.stories.tsx
@@ -1,6 +1,14 @@
+import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import TypeClassifier from '@/components/sidebar/TypeClassifier';
+import { useCreatePlanMutation } from '@/hooks/rq/plan';
+import useClassifiedPlans from '@/hooks/useClassifiedPlans';
+import useDateState from '@/stores/date';
+import planStubManager from '@/stories/apis/data/plan';
+import { createPlanApiHandler, getPlansApiHandler } from '@/stories/apis/plan';
+import { TIMETABLE_SCROLL_STYLE } from '@/styles/timetable';
+import { TPlanType } from '@/types/rq/plan';
 
 export default {
   title: 'Sidebar/Classifier',
@@ -8,8 +16,106 @@ export default {
 } as ComponentMeta<typeof TypeClassifier>;
 
 const Template: ComponentStory<typeof TypeClassifier> = (args) => {
-  return <TypeClassifier {...args} />;
+  const { year, month } = useDateState();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const plans = useClassifiedPlans();
+
+  const typePlans = {
+    task: 0,
+    alarm: 0,
+    event: 0,
+  };
+  plans.forEach(({ type }) => typePlans[type]++);
+
+  const createRandomTypePlan = () => {
+    const random = Math.round(Math.random() * 2);
+    const types = {
+      0: 'task',
+      1: 'alarm',
+      2: 'event',
+    } as { [key: number]: TPlanType };
+
+    createPlanMutateAsync(
+      planStubManager.createStub({ type: types[random] ?? 'task' }),
+    );
+  };
+
+  return (
+    <Container>
+      <div className="category-classifier-plans">
+        <h4>
+          {year}년 {month}월 일정 렌더링
+        </h4>
+        <PlanSummary>
+          <div>총 {plans.length} 개의 일정</div>
+          {Object.entries(typePlans).map(([name, count]) => {
+            return (
+              <div>
+                {name}({count}개)
+              </div>
+            );
+          })}
+        </PlanSummary>
+      </div>
+      <div className="category-classifier-controls">
+        <TestButton onClick={createRandomTypePlan}>
+          랜덤 일정 추가하기
+        </TestButton>
+      </div>
+      <div className="category-classifier-main">
+        <TypeClassifier {...args} />
+      </div>
+    </Container>
+  );
 };
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  .category-classifier-controls {
+    flex: 0;
+    padding: 1rem;
+
+    display: flex;
+    column-gap: 1rem;
+  }
+
+  .category-classifier-plans {
+    width: 100%;
+    flex: 0;
+    padding: 0 1rem;
+  }
+
+  .category-classifier-main {
+    flex: 1 0 0;
+  }
+`;
+
+const PlanSummary = styled.div`
+  ${TIMETABLE_SCROLL_STYLE}
+
+  padding-top: 1rem;
+  display: flex;
+  column-gap: 1rem;
+
+  overflow-x: scroll;
+  overflow-y: hidden;
+`;
+
+const TestButton = styled.button`
+  padding: 0.5rem;
+  border: 1px solid black;
+  border-radius: 8px;
+`;
 
 export const Type = Template.bind({});
 Type.args = {};
+Type.parameters = {
+  msw: {
+    handlers: [getPlansApiHandler, createPlanApiHandler],
+  },
+};

--- a/src/stories/sidebar/TypeClassifier.stories.tsx
+++ b/src/stories/sidebar/TypeClassifier.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import TypeClassifier from '@/components/sidebar/TypeClassifier';
+
+export default {
+  title: 'Sidebar/Classifier',
+  component: TypeClassifier,
+} as ComponentMeta<typeof TypeClassifier>;
+
+const Template: ComponentStory<typeof TypeClassifier> = (args) => {
+  return <TypeClassifier {...args} />;
+};
+
+export const Type = Template.bind({});
+Type.args = {};

--- a/src/stories/utils/createRandomColor.ts
+++ b/src/stories/utils/createRandomColor.ts
@@ -1,0 +1,9 @@
+import { TColor } from '@/types';
+
+const createRandomColor = () => {
+  return `#${Math.round(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}` as TColor;
+};
+
+export default createRandomColor;


### PR DESCRIPTION
- Closes #117 

## ✨ **구현 기능 명세**

### 사이드바에서 일정 분류 기능 활성화

사이드바에서 카테고리, 일정, 분류 등에 따라 일정을 분류할 수 있는 기능을 만들었습니다.
useClassifiedPlans Hook을 통해 분류된 일정을 가져올 수 있습니다.

`useClassifiedPlans`에서는 다음과 같은 State들을 사용해 Plan 배열을 필터링하고 있습니다.
![image](https://github.com/JiPyoTak/plandar-client/assets/55688122/2efcc4fd-11cd-49f0-b3e4-820ec080ca28)

기존의 Timetable, Calendar에서 `useGetPlansQuery`를 `useClassifiedPlans`로 대체하면서 분류된 Plans를 구현할 수 있었습니다.

### 사이드바 일부 버그 수정

* 카테고리 수정 버튼 클릭 시 카테고리 토글 기능 작동하는 버그 해결
* 태그 토글 아이템에서 수정 버튼 삭제
* 카테고리에서 통신이 완료되지 않으면 사이드바에서 보여주지 않던 버그 해결

## 🌄 **스크린샷**

![Category](https://github.com/JiPyoTak/plandar-client/assets/55688122/4790c9ee-75a0-4d65-9001-ebb6f739fd63)
------
![Tag](https://github.com/JiPyoTak/plandar-client/assets/55688122/b9dcea59-f118-4012-8a92-e50d99a2348a)
------
![Type](https://github.com/JiPyoTak/plandar-client/assets/55688122/72a1f0b7-be71-4f32-ae85-4884f5889d4a)

