### PR TITLE
토스트 메시지 사용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import styled from '@emotion/styled';
@@ -7,10 +8,19 @@ import useLogin from './hooks/useLogin';
 import Login from './pages/Login';
 import Home from '@/pages';
 import Test from '@/pages/Test';
+import useUserStore from '@/stores/user';
 import GlobalStyle from '@/styles/GlobalStyle';
+import { toast } from '@/toast';
 
 const App = () => {
   const { isLoading: isLoginLoading } = useLogin();
+  const isFirstTime = useRef(true);
+  const username = useUserStore((state) => state?.user?.username);
+
+  if (isFirstTime.current && username) {
+    isFirstTime.current = false;
+    toast(`${username}님, 환영합니다`);
+  }
 
   return (
     <Wrapper id="App">

--- a/src/components/buttons/ProfileButton/ProfilePopup.tsx
+++ b/src/components/buttons/ProfileButton/ProfilePopup.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import useLogout from '@/hooks/useLogout';
 import useUserStore from '@/stores/user';
 import { FONT_REGULAR_3, FONT_REGULAR_4, FONT_REGULAR_5 } from '@/styles/font';
+import { toast } from '@/toast';
 
 const ProfilePopup = () => {
   const { user } = useUserStore();
@@ -10,8 +11,9 @@ const ProfilePopup = () => {
   const onLogout = async () => {
     try {
       await logout();
+      toast(`${user!.username}님, 안녕히가세요`);
     } catch (e) {
-      alert('로그아웃에 실패했습니다');
+      toast('로그아웃에 실패했습니다');
     }
   };
 

--- a/src/components/common/ColorPicker.tsx
+++ b/src/components/common/ColorPicker.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 
 import { CheckIcon } from '@/components/icons';
 import { SELECTABLE_COLOR } from '@/constants';
+import { ColorCircle } from '@/styles/category';
 import { TColor } from '@/types';
 
 type TColorPickerProps = {
@@ -23,8 +24,8 @@ type TColorPickerProps = {
 type TColorPicker = React.FC<TColorPickerProps>;
 
 const CIRCLE_SIZE = {
-  small: '10px',
-  middle: '14px',
+  small: 10,
+  middle: 14,
 };
 
 const ColorPicker: TColorPicker = ({
@@ -51,14 +52,7 @@ const ColorPicker: TColorPicker = ({
   return (
     <span css={{ position: 'relative' }}>
       <PickerButton onClick={onClickPickerButton} className={className}>
-        <span
-          css={{
-            backgroundColor: selectedColor,
-            width: CIRCLE_SIZE[circleSize],
-            height: CIRCLE_SIZE[circleSize],
-            borderRadius: '50%',
-          }}
-        />
+        <ColorCircle color={selectedColor} size={CIRCLE_SIZE[circleSize]} />
         {additionalComponent}
       </PickerButton>
       {popupOpened && (
@@ -69,7 +63,7 @@ const ColorPicker: TColorPicker = ({
               css={{ position: 'relative' }}
               key={color}
             >
-              <ColorCircle css={{ backgroundColor: color }} />
+              <ColorCircle color={color} size={22} css={{ display: 'block' }} />
               {selectedColor === color && <CheckMarker color={theme.white} />}
             </button>
           ))}
@@ -108,12 +102,6 @@ const Popup = styled.div`
   grid-template-columns: repeat(5, 1fr);
   gap: 10px;
   z-index: 50;
-`;
-
-const ColorCircle = styled.div`
-  width: 22px;
-  height: 22px;
-  border-radius: 100%;
 `;
 
 const CheckMarker = styled(CheckIcon)`

--- a/src/components/modal/plan/Candidates/CandidateItem.tsx
+++ b/src/components/modal/plan/Candidates/CandidateItem.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 
 import { CheckIcon } from '@/components/icons';
 import { SELECTABLE_COLOR } from '@/constants';
+import { ColorCircle } from '@/styles/category';
 import { TColor } from '@/types';
 
 type TCandidateItemProps = ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -41,7 +42,7 @@ const CandidateItem: TCandidateItem = ({
         </>
       ) : (
         <>
-          <ColorCircle css={{ backgroundColor: color }} />
+          <ColorCircle color={color} size={20} />
           <Title>{name}</Title>
           <CheckIconContainer>
             {isSelected && (
@@ -87,12 +88,6 @@ const CheckIconContainer = styled.div`
 const Title = styled.span`
   flex: 1;
   text-align: left;
-`;
-
-const ColorCircle = styled.span`
-  width: 20px;
-  height: 20px;
-  border-radius: 100%;
 `;
 
 export default CandidateItem;

--- a/src/components/modal/plan/Selected/index.tsx
+++ b/src/components/modal/plan/Selected/index.tsx
@@ -14,6 +14,7 @@ import { useEffectModal } from '@/hooks/useEffectModal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import useSelectedPlanState from '@/stores/plan/selectedPlan';
 import { FONT_REGULAR_5 } from '@/styles/font';
+import { toast } from '@/toast';
 import { getPositionByViewPort } from '@/utils/calendar/getPositionByViewPort';
 
 const Selected = () => {
@@ -74,8 +75,15 @@ const Selected = () => {
   });
 
   const deletePlan = () => {
-    mutate(plan.id);
-    clearPlan();
+    mutate(plan.id, {
+      onSuccess: () => {
+        clearPlan();
+        toast(`${plan.title} 일정이 삭제되었습니다`);
+      },
+      onError: () => {
+        toast('일정 삭제에 실패했습니다');
+      },
+    });
   };
 
   const editPlan = () => {

--- a/src/components/modal/plan/category/SelectedCategoryDisplay.tsx
+++ b/src/components/modal/plan/category/SelectedCategoryDisplay.tsx
@@ -5,10 +5,12 @@ import styled from '@emotion/styled';
 
 import ColorPicker from '@/components/common/ColorPicker';
 import { useCategoryUpdate } from '@/hooks/rq/category';
+import { ColorCircle } from '@/styles/category';
 import {
   ClassifierAdditionalFontStyle,
   ClassifierAdditionalMarginRight,
 } from '@/styles/planModal';
+import { toast } from '@/toast';
 import { TColor } from '@/types';
 import { ICategory, ICategoryWithoutId } from '@/types/rq/category';
 
@@ -29,8 +31,7 @@ const SelectedCategoryDisplay: TSelectedCategoryDisplay = ({
   const onSelect = async (newColor: TColor) => {
     // id가 없다면 아직 서버로부터 생성되지 않은 상태므로 return
     if (!Object.hasOwnProperty.call(category, 'id')) {
-      alert('카테고리가 생성되지 않았습니다.');
-      // todo: 토스트 메시지로 실패했다고 알림
+      toast('카테고리가 생성되지 않았습니다');
       return;
     }
 
@@ -40,9 +41,14 @@ const SelectedCategoryDisplay: TSelectedCategoryDisplay = ({
 
       await updateCategory(newCategory);
       onUpdateCategory(newCategory.id);
+      toast(
+        <div>
+          {newCategory.name} 카테고리 색상이 <ColorCircle color={newColor} />
+          으로 수정되었습니다.
+        </div>,
+      );
     } catch (e) {
-      alert('카테고리 수정에 실패했습니다.');
-      // todo: 토스트 메시지로 실패했다고 알림
+      toast('카테고리 수정에 실패했습니다');
     }
   };
 

--- a/src/components/modal/plan/index.tsx
+++ b/src/components/modal/plan/index.tsx
@@ -16,6 +16,8 @@ import PlanTag from '@/components/modal/plan/PlanTag';
 import PlanTitleInput from '@/components/modal/plan/PlanTitleInput';
 import { useCreatePlanMutation, useUpdatePlanMutation } from '@/hooks/rq/plan';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
+import { ColorCircle } from '@/styles/category';
+import { toast } from '@/toast';
 
 type TPlanModalProps = {
   isEdit?: boolean;
@@ -37,7 +39,8 @@ const PlanModal: TPlanModal = ({
       focusedPlan,
       openModal: initOpenModal || (!isDragging && !!focusedPlan),
       clearPlan: clearDraggedPlan,
-      isDisabled: !focusedPlan?.startTime || !focusedPlan?.endTime,
+      isDisabled:
+        !focusedPlan?.startTime || !focusedPlan?.endTime || !focusedPlan?.title,
     }),
     shallow,
   );
@@ -56,12 +59,24 @@ const PlanModal: TPlanModal = ({
     try {
       if (isEdit) {
         await updateMutate({ id, ...rest });
+        toast(
+          <div>
+            <ColorCircle color={focusedPlan.color} />
+            {` ${focusedPlan.title}`} 으로 일정을 수정했습니다
+          </div>,
+        );
       } else {
         await createMutate(rest);
+        toast(
+          <div>
+            <ColorCircle color={focusedPlan.color} />
+            {` ${focusedPlan.title}`} 일정을 생성했습니다
+          </div>,
+        );
       }
       onDone?.();
     } catch (e) {
-      alert('일정 생성에 실패했습니다.');
+      toast(`일정 ${isEdit ? '수정' : '생성'}에 실패했습니다.`);
     }
   };
 

--- a/src/components/sidebar/CategoryClassifier.tsx
+++ b/src/components/sidebar/CategoryClassifier.tsx
@@ -17,6 +17,8 @@ import {
   useCategoryUpdate,
 } from '@/hooks/rq/category';
 import useCategoryClassifierState from '@/stores/classifier/category';
+import { ColorCircle } from '@/styles/category';
+import { toast } from '@/toast';
 import { TColor } from '@/types';
 
 const CategoryClassifier: React.FC = () => {
@@ -41,8 +43,19 @@ const CategoryClassifier: React.FC = () => {
         categoryName: string;
         color: TColor;
       }) => {
-        categoryCreate({ name, color });
-        setModalState(null);
+        try {
+          categoryCreate({ name, color });
+          setModalState(null);
+          toast(
+            <div>
+              <ColorCircle color={color} />
+              {` ${name} `}
+              카테고리를 생성했습니다
+            </div>,
+          );
+        } catch (e) {
+          toast('카테고리 생성에 실패했습니다');
+        }
       },
     });
   };
@@ -65,8 +78,20 @@ const CategoryClassifier: React.FC = () => {
         categoryName: string;
         color: TColor;
       }) => {
-        categoryUpdate({ id, name, color });
-        setModalState(null);
+        try {
+          categoryUpdate({ id, name, color });
+          setModalState(null);
+          toast(
+            <div>
+              <ColorCircle color={originalCategory.color} />
+              {` ${originalCategory.name} `} 카테고리를{' '}
+              <ColorCircle color={color} />
+              {` ${name} `}으로 수정했습니다
+            </div>,
+          );
+        } catch (e) {
+          toast('카테고리 수정에 실패했습니다');
+        }
       },
     });
   };

--- a/src/hooks/usePlanDrag.ts
+++ b/src/hooks/usePlanDrag.ts
@@ -4,6 +4,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useUpdatePlanMutation } from './rq/plan';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
+import { toast } from '@/toast';
 
 export type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>;
 
@@ -105,6 +106,7 @@ const usePlanDrag = () => {
 
       if (focusedPlan.id >= 0 && !shallow(currentPlan, focusedPlan)) {
         await mutateAsync(focusedPlan);
+        toast(`${focusedPlan.title} 일정 날짜가 변경되었습니다`);
       }
 
       timeTypeRef.current = null;

--- a/src/styles/category.ts
+++ b/src/styles/category.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+import { TColor } from '@/types';
+
+const ColorCircle = styled.div<{ color: TColor; size?: number }>`
+  display: inline-block;
+  background-color: ${({ color }) => color};
+  border-radius: 50%;
+  width: ${({ size }) => size ?? 12}px;
+  height: ${({ size }) => size ?? 12}px;
+`;
+
+export { ColorCircle };


### PR DESCRIPTION
- Closes #121 

## ✨ **구현 기능 명세**

구현한 토스트 메시지를 각 상황에 맞게 사용합니다.

* 로그인/로그아웃
* 카테고리 생성/수정시
* 일정 생성/수정시
* 일정 드래그로 기간 변경시
* 에러시

## 🎁 **주목할 점**

### toast 

```ts
export type TToastContent = React.ReactNode;
```

`toast` 함수의 인자인 `TToastContent` 타입은 string이 아닌 ReactNode 입니다. 즉, string 뿐만아니라 태그도 들어갈 수 있습니다. 이렇게 만들어 줌으로써 토스트 메시지에 일정과 카테고리의 색상에 대한 정보도 줄 수 있도록 하였습니다.

### App.tsx

```tsx
const App = () => {
  const { isLoading: isLoginLoading } = useLogin();
  const isFirstTime = useRef(true);
  const username = useUserStore((state) => state?.user?.username);

  if (isFirstTime.current && username) {
    isFirstTime.current = false;
    toast(`${username}님, 환영합니다`);
  }
  ...
```

위에서 useRef를 이용하여 `isFirstTime` 을 관리하고 있습니다. 이것을 해준 이유는 다음과 같습니다.

![toast1](https://github.com/JiPyoTak/plandar-client/assets/32933980/ffcc7c7d-a676-49b4-9b99-4b3c9a616890) 

위처럼 여러 번에 걸쳐 토스트 메시지가 보여지는 것을 방지해주기 위해 `isFirstTime`을 사용하였습니다.

## 🌄 **스크린샷**

#### 카테고리 생성시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/74c734ac-468c-45cd-ad89-192d8d8d2306)

#### 카테고리 수정시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/1d2a1f57-6d7c-49b9-80db-048f52a2c577)

#### 일정생성 모달창에서 카테고리 색상 변경시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/7574a161-667f-4fe4-9643-8b91bfeb7c08)

#### 일정 생성시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/9da6dfdd-ae31-4124-9210-c8be46e3b04d)

#### 드래그로 일정 날짜 변경시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/490a37f8-f1e2-4040-95f9-65341c6391a9)

#### 로그아웃시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/c1310d44-a1f3-4829-9de7-4c64c2614b08)

#### 로그인시
![image](https://github.com/JiPyoTak/plandar-client/assets/32933980/ccd83681-e47f-4d11-9a89-4707b4907f1e)



#### 드래그로 일정 날짜 변경시

