### PR TITLE
사이드 바 View 변경사항 추가 - 스켈레톤 및 빈 화면

### DIFF
--- a/src/components/common/classifier/ClassifierGuide.tsx
+++ b/src/components/common/classifier/ClassifierGuide.tsx
@@ -1,0 +1,47 @@
+import React, { PropsWithChildren } from 'react';
+
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import IconFrameComponent from '@/components/core/IconFrameComponent';
+import { FONT_REGULAR_4 } from '@/styles/font';
+
+type TProps = PropsWithChildren<{
+  data?: unknown[];
+  icon?: ReturnType<typeof IconFrameComponent>;
+}>;
+
+const TEXT_COLOR = 'text3';
+const ClassifierGuide: React.FC<TProps> = ({ children, data = [], icon }) => {
+  const theme = useTheme();
+  const IconComponent = icon;
+
+  if (data?.length) return <></>;
+
+  return (
+    <Container>
+      {IconComponent && (
+        <IconComponent
+          css={{ marginBottom: '0.5rem' }}
+          color={theme[TEXT_COLOR]}
+        />
+      )}
+      {children}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  ${FONT_REGULAR_4}
+  padding: 1rem 0;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: 0.25rem;
+
+  color: ${({ theme }) => theme[TEXT_COLOR]};
+`;
+
+export default ClassifierGuide;

--- a/src/components/common/classifier/ClassifierGuide.tsx
+++ b/src/components/common/classifier/ClassifierGuide.tsx
@@ -7,16 +7,16 @@ import IconFrameComponent from '@/components/core/IconFrameComponent';
 import { FONT_REGULAR_4 } from '@/styles/font';
 
 type TProps = PropsWithChildren<{
-  data?: unknown[];
+  isShow: boolean;
   icon?: ReturnType<typeof IconFrameComponent>;
 }>;
 
 const TEXT_COLOR = 'text3';
-const ClassifierGuide: React.FC<TProps> = ({ children, data = [], icon }) => {
+const ClassifierGuide: React.FC<TProps> = ({ children, isShow, icon }) => {
   const theme = useTheme();
   const IconComponent = icon;
 
-  if (data?.length) return <></>;
+  if (!isShow) return <></>;
 
   return (
     <Container>

--- a/src/components/common/classifier/ClassifierItem.tsx
+++ b/src/components/common/classifier/ClassifierItem.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 
 import { CheckIcon, PencilIcon } from '@/components/common/icons';
 import { SELECTABLE_COLOR } from '@/constants';
+import { SKELETON_BACKGROUND_STYLE } from '@/styles';
 import { TColor } from '@/types';
 
 type TProps = {
@@ -14,9 +15,7 @@ type TProps = {
   onEdit?: (...args: unknown[]) => unknown;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-const CLASSIFIER_EDITABLE_ITEM_CLASS = 'classifier-item-edit';
-
-const ClassifierItem: React.FC<TProps> = ({
+const ClassifierItem: React.FC<TProps> & { Skeleton: typeof SkeletonUI } = ({
   isActive,
   color = SELECTABLE_COLOR[0],
   text,
@@ -42,16 +41,19 @@ const ClassifierItem: React.FC<TProps> = ({
       <span css={{ flex: 1 }}>{text}</span>
       {onEdit && (
         <button onClick={onPencilEdit}>
-          <PencilIcon
-            className={CLASSIFIER_EDITABLE_ITEM_CLASS}
-            width={20}
-            height={20}
-          />
+          <PencilIcon width={20} height={20} />
         </button>
       )}
     </Wrapper>
   );
 };
+
+const SkeletonUI: React.FC = () => (
+  <Wrapper>
+    <CircleDiv css={SKELETON_BACKGROUND_STYLE} />
+    <div css={[{ flex: 1, height: '100%' }, SKELETON_BACKGROUND_STYLE]} />
+  </Wrapper>
+);
 
 const Wrapper = styled.div`
   width: 100%;
@@ -61,13 +63,6 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   column-gap: 1rem;
-
-  & > .${CLASSIFIER_EDITABLE_ITEM_CLASS} {
-    visibility: hidden;
-  }
-  &:hover > .${CLASSIFIER_EDITABLE_ITEM_CLASS} {
-    visibility: visible;
-  }
 
   cursor: pointer;
 `;
@@ -83,5 +78,5 @@ const CircleDiv = styled.div`
   border-radius: 50%;
 `;
 
-export { CLASSIFIER_EDITABLE_ITEM_CLASS };
+ClassifierItem.Skeleton = SkeletonUI;
 export default ClassifierItem;

--- a/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
@@ -1,10 +1,11 @@
 import React, { MouseEventHandler, useState } from 'react';
 
+import ClassifierGuide from '@/components/common/classifier/ClassifierGuide';
 import ClassifierItem from '@/components/common/classifier/ClassifierItem';
 import ClassifierTitle, {
   CLASSIFIER_TITLE_ICON_SIZE,
 } from '@/components/common/classifier/ClassifierTitle';
-import { PlusIcon } from '@/components/common/icons';
+import { CategoryIcon, PlusIcon } from '@/components/common/icons';
 import Dropdown from '@/components/core/dropdown';
 import CategoryModal, {
   TCategoryModalProps,
@@ -112,6 +113,10 @@ const CategoryClassifier: React.FC = () => {
               }
             />
           </Dropdown.Controller>
+          <ClassifierGuide icon={CategoryIcon} data={categoryData}>
+            <span>카테고리를 만들어서</span>
+            <span>일정을 관리해보세요!</span>
+          </ClassifierGuide>
           {categoryData?.map(({ id, name, color }) => (
             <ClassifierItem
               key={id}

--- a/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
@@ -22,7 +22,8 @@ import { ColorCircle } from '@/styles/category';
 import { TColor } from '@/types';
 
 const CategoryClassifier: React.FC = () => {
-  const { data: categoryData } = useCategoryQuery();
+  const { data: categoryData, isLoading: isLoadingCategory } =
+    useCategoryQuery();
   const { mutate: categoryCreate } = useCategoryCreate();
   const { mutate: categoryUpdate } = useCategoryUpdate();
   const [modalState, setModalState] = useState<TCategoryModalProps | null>(
@@ -117,6 +118,10 @@ const CategoryClassifier: React.FC = () => {
             <span>카테고리를 만들어서</span>
             <span>일정을 관리해보세요!</span>
           </ClassifierGuide>
+          {isLoadingCategory &&
+            [...Array(2)].map((_, index) => (
+              <ClassifierItem.Skeleton key={index} />
+            ))}
           {categoryData?.map(({ id, name, color }) => (
             <ClassifierItem
               key={id}

--- a/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
@@ -116,7 +116,7 @@ const CategoryClassifier: React.FC = () => {
           </Dropdown.Controller>
           <ClassifierGuide
             icon={CategoryIcon}
-            isShow={!!categoryData?.length && !isLoadingCategory}
+            isShow={!categoryData?.length && !isLoadingCategory}
           >
             <span>카테고리를 만들어서</span>
             <span>일정을 관리해보세요!</span>

--- a/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/CategoryClassifier.tsx
@@ -114,7 +114,10 @@ const CategoryClassifier: React.FC = () => {
               }
             />
           </Dropdown.Controller>
-          <ClassifierGuide icon={CategoryIcon} data={categoryData}>
+          <ClassifierGuide
+            icon={CategoryIcon}
+            isShow={!!categoryData?.length && !isLoadingCategory}
+          >
             <span>카테고리를 만들어서</span>
             <span>일정을 관리해보세요!</span>
           </ClassifierGuide>

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -25,7 +25,7 @@ const TagClassifier: React.FC = () => {
   // FIXME : hook으로 빼내면서 변수 할당 해주겠습니다.
   const [sm, em] = getStartAndEndDate(referenceDate);
 
-  const { data } = useGetPlansQuery({
+  const { data, isLoading: isLoadingPlan } = useGetPlansQuery({
     timemin: sm.format(),
     timemax: em.format(),
   });
@@ -71,6 +71,10 @@ const TagClassifier: React.FC = () => {
           <span>일정에 태그를 추가해서</span>
           <span>일정을 분류해보세요!</span>
         </ClassifierGuide>
+        {isLoadingPlan &&
+          [...Array(2)].map((_, index) => (
+            <ClassifierItem.Skeleton key={index} />
+          ))}
         {tags.map((title) => (
           <ClassifierItem
             key={title}

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -2,8 +2,10 @@ import React, { useMemo } from 'react';
 
 import moment from 'moment';
 
+import ClassifierGuide from '@/components/common/classifier/ClassifierGuide';
 import ClassifierItem from '@/components/common/classifier/ClassifierItem';
 import ClassifierTitle from '@/components/common/classifier/ClassifierTitle';
+import { TagIcon } from '@/components/common/icons';
 import Dropdown from '@/components/core/dropdown';
 import { useGetPlansQuery } from '@/hooks/query/plan';
 import useTagClassifierState from '@/stores/classifier/tag';
@@ -65,6 +67,10 @@ const TagClassifier: React.FC = () => {
         <Dropdown.Controller>
           <ClassifierTitle title={'태그'} />
         </Dropdown.Controller>
+        <ClassifierGuide icon={TagIcon} data={tags}>
+          <span>일정에 태그를 추가해서</span>
+          <span>일정을 분류해보세요!</span>
+        </ClassifierGuide>
         {tags.map((title) => (
           <ClassifierItem
             key={title}

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -67,7 +67,10 @@ const TagClassifier: React.FC = () => {
         <Dropdown.Controller>
           <ClassifierTitle title={'태그'} />
         </Dropdown.Controller>
-        <ClassifierGuide icon={TagIcon} data={tags}>
+        <ClassifierGuide
+          icon={TagIcon}
+          isShow={!!tags?.length && !isLoadingPlan}
+        >
           <span>일정에 태그를 추가해서</span>
           <span>일정을 분류해보세요!</span>
         </ClassifierGuide>

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -69,7 +69,7 @@ const TagClassifier: React.FC = () => {
         </Dropdown.Controller>
         <ClassifierGuide
           icon={TagIcon}
-          isShow={!!tags?.length && !isLoadingPlan}
+          isShow={!tags?.length && !isLoadingPlan}
         >
           <span>일정에 태그를 추가해서</span>
           <span>일정을 분류해보세요!</span>

--- a/src/stories/apis/data/index.ts
+++ b/src/stories/apis/data/index.ts
@@ -58,9 +58,14 @@ class StubManager<Data extends { id: number }> {
     return this.data.splice(index, 1)[0];
   }
 
-  public clear() {
-    this.id = this.initialDataArray.length;
-    this.data = [...this.initialDataArray];
+  public clear(forceClear?: boolean) {
+    if (forceClear) {
+      this.id = 0;
+      this.data = [];
+    } else {
+      this.id = this.initialDataArray.length;
+      this.data = [...this.initialDataArray];
+    }
   }
 
   public getId() {

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -1,5 +1,9 @@
+import { useReducer } from 'react';
+
 import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { useQueryClient } from '@tanstack/react-query';
 
 import CategoryClassifier from '@/components/home/sidebar/content/classifier/CategoryClassifier';
 import { useCategoryCreate, useCategoryQuery } from '@/hooks/query/category';
@@ -26,6 +30,8 @@ const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
   const plans = useClassifiedPlans();
   const { mutateAsync: createCategoryMutateAsync } = useCategoryCreate();
   const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const queryClient = useQueryClient();
+  const forceUpdate = useReducer(() => ({}), {})[1];
 
   const createCategory = () => {
     createCategoryMutateAsync(categoryStubManager.createStub());
@@ -37,6 +43,12 @@ const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
 
     const randomId = Math.round(Math.random() * (maxId - 1)) + 1;
     createPlanMutateAsync(planStubManager.createStub({ categoryId: randomId }));
+  };
+
+  const clearCategory = (forceClear: boolean) => () => {
+    categoryStubManager.clear(forceClear);
+    queryClient.clear();
+    forceUpdate();
   };
 
   const { data } = useCategoryQuery();
@@ -80,6 +92,12 @@ const Template: ComponentStory<typeof CategoryClassifier> = (args) => {
         <TestButton onClick={createCategory}>카테고리 추가하기</TestButton>
         <TestButton onClick={createPlan}>
           랜덤 카테고리 일정 생성하기
+        </TestButton>
+        <TestButton onClick={clearCategory(true)}>
+          카테고리 전부 삭제하기
+        </TestButton>
+        <TestButton onClick={clearCategory(false)}>
+          카테고리 리셋하기
         </TestButton>
       </div>
       <div className="category-classifier-main">

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,21 @@
+import { css, keyframes } from '@emotion/react';
+
+import { theme } from '@/styles/theme';
+
+const skeletonAnimation = keyframes`
+  0% {
+      background-color: ${theme.background4}33;
+  }
+  50% {
+      background-color: ${theme.background4}66;
+  }
+  100% {
+      background-color: ${theme.background4}33;
+  }
+`;
+
+const SKELETON_BACKGROUND_STYLE = css`
+  animation: ${skeletonAnimation} 2s infinite ease-in-out;
+`;
+
+export { SKELETON_BACKGROUND_STYLE };


### PR DESCRIPTION
- Closes #141

## ✨ **구현 기능 명세**

### 사이드바의 Category, Tag 내용물이 없을 때 화면

React-Query의 API가 끝난 뒤 사이드바의 내용물이 없을 때 빈 화면을 보여줄 수 있도록 View를 변경합니다.

### 사이드바의 스켈레톤 화면

React-Query의 API가 시작된 뒤 API 요청이 진행될 때에는 Skeleton UI를 보여줄 수 있도록 합니다.
Skeleton Component는 Emotion Component를 재사용하기 위해 Compound로 선언하고 있습니다.

## 🌄 **스크린샷**

|빈 화면|스켈레톤 UI|
|:---:|:---:|
|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/040f2d94-7391-4d3c-a667-162ca3c034dd" alt="Empty Sidebar" width=350 />|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/8f1a4be0-8d37-4bdc-9ae3-052483b4342b" alt="Skeleton Sidebar" width=350 />|
