### PR TITLE
전역 Date 상태가 범위를 가질 수 있도록 추가

### DIFF
--- a/src/components/core/buttons/CalendarUnitButton.tsx
+++ b/src/components/core/buttons/CalendarUnitButton.tsx
@@ -8,15 +8,15 @@ import { CALENDAR_UNIT } from '@/constants';
 import useDateState from '@/stores/date';
 
 const LABEL_LEFT = {
-  [CALENDAR_UNIT[0]]: '5px',
-  [CALENDAR_UNIT[1]]: 'calc(50% - 25px)',
-  [CALENDAR_UNIT[2]]: 'calc(100% - 55px)',
+  [CALENDAR_UNIT.day]: '5px',
+  [CALENDAR_UNIT.week]: 'calc(50% - 25px)',
+  [CALENDAR_UNIT.month]: 'calc(100% - 55px)',
 } as const;
 
 const CALENDAR_UNIT_TEXT = {
-  [CALENDAR_UNIT[0]]: '일',
-  [CALENDAR_UNIT[1]]: '주',
-  [CALENDAR_UNIT[2]]: '월',
+  [CALENDAR_UNIT.day]: '일',
+  [CALENDAR_UNIT.week]: '주',
+  [CALENDAR_UNIT.month]: '월',
 } as const;
 
 const CalendarUnitButton: React.FC = () => {
@@ -31,7 +31,7 @@ const CalendarUnitButton: React.FC = () => {
   return (
     <CalendarUnitWrapper>
       <CalendarUnitLabel css={{ left: LABEL_LEFT[calendarUnit] }} />
-      {CALENDAR_UNIT.map((unit) => (
+      {Object.values(CALENDAR_UNIT).map((unit) => (
         <CalendarUnitText
           key={unit}
           css={

--- a/src/components/core/buttons/CalendarUnitButton.tsx
+++ b/src/components/core/buttons/CalendarUnitButton.tsx
@@ -9,12 +9,14 @@ import useDateState from '@/stores/date';
 
 const LABEL_LEFT = {
   [CALENDAR_UNIT.day]: '5px',
+  [CALENDAR_UNIT.days]: '5px',
   [CALENDAR_UNIT.week]: 'calc(50% - 25px)',
   [CALENDAR_UNIT.month]: 'calc(100% - 55px)',
 } as const;
 
 const CALENDAR_UNIT_TEXT = {
   [CALENDAR_UNIT.day]: '일',
+  [CALENDAR_UNIT.days]: '일',
   [CALENDAR_UNIT.week]: '주',
   [CALENDAR_UNIT.month]: '월',
 } as const;

--- a/src/components/core/buttons/CalendarUnitButton.tsx
+++ b/src/components/core/buttons/CalendarUnitButton.tsx
@@ -9,17 +9,21 @@ import useDateState from '@/stores/date';
 
 const LABEL_LEFT = {
   [CALENDAR_UNIT.day]: '5px',
-  [CALENDAR_UNIT.days]: '5px',
   [CALENDAR_UNIT.week]: 'calc(50% - 25px)',
   [CALENDAR_UNIT.month]: 'calc(100% - 55px)',
 } as const;
 
 const CALENDAR_UNIT_TEXT = {
   [CALENDAR_UNIT.day]: '일',
-  [CALENDAR_UNIT.days]: '일',
   [CALENDAR_UNIT.week]: '주',
   [CALENDAR_UNIT.month]: '월',
 } as const;
+
+const CALENDAR_SELECTIONS = [
+  CALENDAR_UNIT.day,
+  CALENDAR_UNIT.week,
+  CALENDAR_UNIT.month,
+];
 
 const CalendarUnitButton: React.FC = () => {
   const theme = useTheme();
@@ -29,15 +33,18 @@ const CalendarUnitButton: React.FC = () => {
       setCalendarUnit,
     }),
   );
+  // * : days (range 선택 시) 주 단위 달력으로 판단
+  const selectedUnit =
+    calendarUnit === CALENDAR_UNIT.days ? CALENDAR_UNIT.week : calendarUnit;
 
   return (
     <CalendarUnitWrapper>
-      <CalendarUnitLabel css={{ left: LABEL_LEFT[calendarUnit] }} />
-      {Object.values(CALENDAR_UNIT).map((unit) => (
+      <CalendarUnitLabel css={{ left: LABEL_LEFT[selectedUnit] }} />
+      {CALENDAR_SELECTIONS.map((unit) => (
         <CalendarUnitText
           key={unit}
           css={
-            calendarUnit === unit && {
+            selectedUnit === unit && {
               color: theme.title_active,
             }
           }

--- a/src/components/home/main/header/HeaderButtons.tsx
+++ b/src/components/home/main/header/HeaderButtons.tsx
@@ -13,14 +13,14 @@ const HeaderButtons = () => {
   const {
     referenceDate,
     setReferenceDate,
-    decreaseStoreMonth,
-    increaseStoreMonth,
+    increaseReferenceDate,
+    decreaseReferenceDate,
   } = useDateState();
   const calendarUnit = useDateState(({ calendarUnit }) => calendarUnit);
 
   const onClickLeftButton = () => {
     if (calendarUnit === 'month') {
-      decreaseStoreMonth();
+      decreaseReferenceDate();
     } else {
       const decreaseTerm = calendarUnit === 'week' ? 7 : 1;
       const newDate = moment(referenceDate).subtract(decreaseTerm, 'day');
@@ -30,7 +30,7 @@ const HeaderButtons = () => {
 
   const onClickRightButton = () => {
     if (calendarUnit === 'month') {
-      increaseStoreMonth();
+      increaseReferenceDate();
     } else {
       const decreaseTerm = calendarUnit === 'week' ? 7 : 1;
       const newDate = moment(referenceDate).add(decreaseTerm, 'day');

--- a/src/components/home/main/header/HeaderButtons.tsx
+++ b/src/components/home/main/header/HeaderButtons.tsx
@@ -10,33 +10,14 @@ import TodayButton from '@/components/core/buttons/TodayButton';
 import useDateState from '@/stores/date';
 
 const HeaderButtons = () => {
-  const {
-    referenceDate,
-    setReferenceDate,
-    increaseReferenceDate,
-    decreaseReferenceDate,
-  } = useDateState();
-  const calendarUnit = useDateState(({ calendarUnit }) => calendarUnit);
-
-  const onClickLeftButton = () => {
-    if (calendarUnit === 'month') {
-      decreaseReferenceDate();
-    } else {
-      const decreaseTerm = calendarUnit === 'week' ? 7 : 1;
-      const newDate = moment(referenceDate).subtract(decreaseTerm, 'day');
-      setReferenceDate(newDate);
-    }
-  };
-
-  const onClickRightButton = () => {
-    if (calendarUnit === 'month') {
-      increaseReferenceDate();
-    } else {
-      const decreaseTerm = calendarUnit === 'week' ? 7 : 1;
-      const newDate = moment(referenceDate).add(decreaseTerm, 'day');
-      setReferenceDate(newDate);
-    }
-  };
+  const { setReferenceDate, increaseReferenceDate, decreaseReferenceDate } =
+    useDateState(
+      ({ setReferenceDate, increaseReferenceDate, decreaseReferenceDate }) => ({
+        setReferenceDate,
+        increaseReferenceDate,
+        decreaseReferenceDate,
+      }),
+    );
 
   const onClickTodayButton = () => {
     setReferenceDate(moment());
@@ -46,8 +27,8 @@ const HeaderButtons = () => {
     <Container>
       <PlusButton />
       <DirectionButtons
-        onClickLeftButton={onClickLeftButton}
-        onClickRightButton={onClickRightButton}
+        onClickLeftButton={decreaseReferenceDate}
+        onClickRightButton={increaseReferenceDate}
       />
       <TodayButton onClick={onClickTodayButton} />
     </Container>

--- a/src/components/home/main/timetable/index.tsx
+++ b/src/components/home/main/timetable/index.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
-import moment from 'moment';
-
 import TimetableScroll from './TimetableScroll';
 import TimetableView from './view';
 import TimetableHeader from '@/components/home/main/timetable/TimetableHeader';
@@ -14,29 +12,19 @@ import {
   TIMETABLE_SCROLL_WIDTH,
 } from '@/styles/timetable';
 
-type TProps = {
-  rangeAmount?: number;
-};
-
-const Timetable: React.FC<TProps> = ({ rangeAmount = 1 }) => {
-  const { referenceDate, calendarUnit } = useDateState(
-    ({ referenceDate, calendarUnit }) => ({
-      referenceDate,
-      calendarUnit,
-    }),
+const Timetable: React.FC = () => {
+  const referenceDateRange = useDateState(
+    ({ referenceDateRange }) => referenceDateRange,
   );
 
-  // 주 선택하면 선택한 날짜 상관없이 해당 주를 보여주기
-  const startMoment = moment(referenceDate);
-  if (calendarUnit === 'week') {
-    rangeAmount = 7;
-    startMoment.startOf('week');
-  }
-
   // 범위에 해당하는 일자의 Moment들 생성
-  const range = Math.min(rangeAmount, 7);
+  const { startMoment, endMoment } = referenceDateRange;
+  const range = Math.max(
+    endMoment.clone().add(1, 'ms').diff(startMoment, 'day'),
+    1,
+  );
   const dateMoments = Array.from(Array(range), (_, index) =>
-    startMoment.clone().add(index, 'days'),
+    startMoment.clone().add(index, 'day'),
   );
   const showHeader = range > 1;
 

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -1,65 +1,28 @@
 import React, { useMemo } from 'react';
 
-import moment from 'moment';
-
 import ClassifierGuide from '@/components/common/classifier/ClassifierGuide';
 import ClassifierItem from '@/components/common/classifier/ClassifierItem';
 import ClassifierTitle from '@/components/common/classifier/ClassifierTitle';
 import { TagIcon } from '@/components/common/icons';
 import Dropdown from '@/components/core/dropdown';
-import { useGetPlansQuery } from '@/hooks/query/plan';
+import useRangedPlans from '@/hooks/useRangedPlans';
 import useTagClassifierState from '@/stores/classifier/tag';
-import useDateState from '@/stores/date';
-import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 
 const TagClassifier: React.FC = () => {
   const { hiddenTags, toggleTagShow } = useTagClassifierState();
-
-  // TODO : make hook
-  const { referenceDate, calendarUnit } = useDateState(
-    ({ referenceDate, calendarUnit }) => ({
-      referenceDate,
-      calendarUnit,
-    }),
-  );
-  // FIXME : hook으로 빼내면서 변수 할당 해주겠습니다.
-  const [sm, em] = getStartAndEndDate(referenceDate);
-
-  const { data, isLoading: isLoadingPlan } = useGetPlansQuery({
-    timemin: sm.format(),
-    timemax: em.format(),
-  });
-
-  // TODO: Timetable의 로직과 같은 로직을 사용하고 있습니다.
-  /// State Store 변경을 해서 시간 개념을 통일하는게 좋아보입니다.
-  //// 주 선택하면 선택한 날짜 상관없이 해당 주를 보여주기
-  let rangeAmount = 0;
-  const startMoment = moment(referenceDate);
-  if (calendarUnit === 'month') {
-    rangeAmount = 42;
-    startMoment.startOf('month').startOf('week');
-  } else if (calendarUnit === 'week') {
-    rangeAmount = 7;
-    startMoment.startOf('week');
-  }
-  const endMoment = moment(startMoment).add(rangeAmount + 1, 'day');
-
-  const planData = (data ?? []).filter(
-    ({ startTime, endTime }) =>
-      !(endMoment.isSameOrBefore(startTime) || startMoment.isAfter(endTime)),
-  );
+  const { data: plans, isLoading: isLoadingPlan } = useRangedPlans();
 
   const tags = useMemo(() => {
     const tagNameSet = new Set<string>();
 
-    for (const { tags } of planData ?? []) {
+    for (const { tags } of plans) {
       for (const tag of tags ?? []) {
         tagNameSet.add(tag);
       }
     }
 
     return [...tagNameSet].sort();
-  }, [planData, calendarUnit, referenceDate]);
+  }, [plans]);
 
   return (
     <div css={{ padding: '1rem 0' }}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,6 +5,7 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 
 const CALENDAR_UNIT = {
   day: 'day',
+  days: 'days',
   week: 'week',
   month: 'month',
 } as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,11 @@ import { TColor } from '@/types';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
-const CALENDAR_UNIT = ['day', 'week', 'month'] as const;
+const CALENDAR_UNIT = {
+  day: 'day',
+  week: 'week',
+  month: 'month',
+} as const;
 
 const DAY_OF_WEEK_UNIT = ['일', '월', '화', '수', '목', '금', '토'] as const;
 

--- a/src/hooks/useClassifiedPlans.ts
+++ b/src/hooks/useClassifiedPlans.ts
@@ -1,10 +1,8 @@
-import { useGetPlansQuery } from '@/hooks/query/plan';
+import useRangedPlans from '@/hooks/useRangedPlans';
 import useCategoryClassifierState from '@/stores/classifier/category';
 import useTagClassifierState from '@/stores/classifier/tag';
 import useTypeClassifierState from '@/stores/classifier/type';
-import useDateState from '@/stores/date';
 import { IPlan } from '@/types/query/plan';
-import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 
 const useClassifiedPlans = () => {
   const hiddenCategories = useCategoryClassifierState(
@@ -18,17 +16,7 @@ const useClassifiedPlans = () => {
       showTask,
     }),
   );
-
-  // TODO : make hook
-  const { referenceDate } = useDateState(({ referenceDate }) => ({
-    referenceDate,
-  }));
-  const [startMoment, endMoment] = getStartAndEndDate(referenceDate);
-
-  const { data: plans } = useGetPlansQuery({
-    timemin: startMoment.format(),
-    timemax: endMoment.format(),
-  });
+  const { data: plans } = useRangedPlans();
 
   const classifiedPlans = (plans ?? []).reduce((result, plan) => {
     const { categoryId, tags } = plan;

--- a/src/hooks/useClassifiedPlans.ts
+++ b/src/hooks/useClassifiedPlans.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import useRangedPlans from '@/hooks/useRangedPlans';
 import useCategoryClassifierState from '@/stores/classifier/category';
 import useTagClassifierState from '@/stores/classifier/tag';
@@ -18,19 +20,22 @@ const useClassifiedPlans = () => {
   );
   const { data: plans } = useRangedPlans();
 
-  const classifiedPlans = (plans ?? []).reduce((result, plan) => {
-    const { categoryId, tags } = plan;
+  const classifiedPlans = useMemo(() => {
+    return plans.reduce((result, plan) => {
+      const { categoryId, tags } = plan;
 
-    if (categoryId && hiddenCategories.has(categoryId)) return result;
-    if (tags.length && tags.every((tag) => hiddenTags.has(tag))) return result;
-    if (!showAlarm && plan.type === 'alarm') return result;
-    if (!showEvent && plan.type === 'event') return result;
-    if (!showTask && plan.type === 'task') return result;
+      if (categoryId && hiddenCategories.has(categoryId)) return result;
+      if (tags.length && tags.every((tag) => hiddenTags.has(tag)))
+        return result;
+      if (!showAlarm && plan.type === 'alarm') return result;
+      if (!showEvent && plan.type === 'event') return result;
+      if (!showTask && plan.type === 'task') return result;
 
-    result.push(plan);
+      result.push(plan);
 
-    return result;
-  }, [] as IPlan[]);
+      return result;
+    }, [] as IPlan[]);
+  }, [plans, hiddenCategories, hiddenTags, showAlarm, showEvent, showTask]);
 
   return classifiedPlans;
 };

--- a/src/hooks/useRangedPlans.ts
+++ b/src/hooks/useRangedPlans.ts
@@ -7,11 +7,11 @@ import useDateState from '@/stores/date';
 import { IPlan } from '@/types/query/plan';
 import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 
-const useRangedPlans = (function stateMaker() {
+const useRangedPlans = (function () {
   let plansCache: IPlan[] = [];
   let updateKeys = {};
 
-  return function useHook() {
+  return function () {
     const { referenceDate, referenceDateRange, calendarUnit } = useDateState(
       ({ referenceDate, referenceDateRange, calendarUnit }) => ({
         referenceDate,

--- a/src/hooks/useRangedPlans.ts
+++ b/src/hooks/useRangedPlans.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+
+import { shallow } from 'zustand/shallow';
+
+import { useGetPlansQuery } from '@/hooks/query/plan';
+import useDateState from '@/stores/date';
+import { IPlan } from '@/types/query/plan';
+import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
+
+const useRangedPlans = (function stateMaker() {
+  let plansCache: IPlan[] = [];
+  let updateKeys = {};
+
+  return function useHook() {
+    const { referenceDate, referenceDateRange, calendarUnit } = useDateState(
+      ({ referenceDate, referenceDateRange, calendarUnit }) => ({
+        referenceDate,
+        referenceDateRange,
+        calendarUnit,
+      }),
+    );
+    const [startDate, endDate] = getStartAndEndDate(referenceDate);
+
+    const { data, ...rest } = useGetPlansQuery({
+      timemin: startDate.format(),
+      timemax: endDate.format(),
+    });
+
+    const plans = useMemo(() => {
+      const keys = {
+        referenceDate,
+        referenceDateRange,
+        calendarUnit,
+        data,
+      };
+      if (!shallow(keys, updateKeys)) {
+        const { startMoment, endMoment } = referenceDateRange;
+
+        plansCache =
+          data?.filter(
+            ({ startTime, endTime }) =>
+              !(startMoment.isAfter(endTime) || endMoment.isBefore(startTime)),
+          ) ?? [];
+        updateKeys = keys;
+      }
+
+      return plansCache;
+    }, [referenceDate, referenceDateRange, calendarUnit, data]);
+
+    return { data: plans, ...rest };
+  };
+})();
+
+export default useRangedPlans;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,9 +12,10 @@ import SelectedPlanModal from '@/components/modal/plan/select';
 import useDateState from '@/stores/date';
 
 const CALENDAR_COMPONENTS = {
-  month: MainCalendar,
-  week: Timetable,
   day: Timetable,
+  days: Timetable,
+  week: Timetable,
+  month: MainCalendar,
 } as const;
 
 const Home: React.FC = () => {

--- a/src/stores/date.ts
+++ b/src/stores/date.ts
@@ -4,40 +4,91 @@ import { create } from 'zustand';
 
 import { CALENDAR_UNIT } from '@/constants';
 import { TCalendarUnit } from '@/types';
+import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
 
 type TDateState = {
   referenceDate: Moment;
-  referenceDateRange: number;
+  referenceDateRange: {
+    startMoment: Moment;
+    endMoment: Moment;
+  };
   calendarUnit: TCalendarUnit;
 };
 
-const initialState = {
-  referenceDate: moment(),
-  referenceDateRange: 1,
-  calendarUnit: CALENDAR_UNIT.month,
-} as const;
+const createInitialState = () => {
+  const referenceDate = moment();
+  const [startMoment, endMoment] = getStartAndEndDate(referenceDate);
+
+  return {
+    referenceDate,
+    referenceDateRange: {
+      startMoment,
+      endMoment,
+    },
+    calendarUnit: CALENDAR_UNIT.month,
+  } as const;
+};
 
 type TDateAction = {
-  setReferenceDate: (date: MomentInput) => void;
+  setReferenceDate: (referenceDate: MomentInput) => void;
   setCalendarUnit: (calendarUnit: TCalendarUnit) => void;
   increaseReferenceDate: () => void;
   decreaseReferenceDate: () => void;
+  setDateWithRange: (options?: {
+    referenceDate?: MomentInput;
+    calendarUnit?: TCalendarUnit;
+    rangeAmount?: number;
+  }) => void;
 };
 
-const useDateState = create<TDateState & TDateAction>((set) => ({
-  ...initialState,
-  setReferenceDate: (date) => set({ referenceDate: moment(date) }),
-  setCalendarUnit: (calendarUnit) => set({ calendarUnit }),
-  increaseReferenceDate: () =>
-    set(({ referenceDate, calendarUnit }) => {
+const useDateState = create<TDateState & TDateAction>((set, get) => ({
+  ...createInitialState(),
+  setReferenceDate: (referenceDate) =>
+    get().setDateWithRange({ referenceDate }),
+  setCalendarUnit: (calendarUnit) => get().setDateWithRange({ calendarUnit }),
+  increaseReferenceDate: () => {
+    const { referenceDate: prevDate, calendarUnit, setDateWithRange } = get();
+    const referenceDate = moment(prevDate).add(1, calendarUnit);
+    setDateWithRange({ referenceDate });
+  },
+  decreaseReferenceDate: () => {
+    const { referenceDate: prevDate, calendarUnit, setDateWithRange } = get();
+    const referenceDate = moment(prevDate).subtract(1, calendarUnit);
+    setDateWithRange({ referenceDate });
+  },
+  setDateWithRange: ({ referenceDate, calendarUnit, rangeAmount } = {}) =>
+    set(({ referenceDate: prevDate, calendarUnit: prevUnit }) => {
+      referenceDate = moment(referenceDate ?? prevDate);
+      calendarUnit = calendarUnit ?? prevUnit;
+
+      let referenceDateRange = {} as TDateState['referenceDateRange'];
+      if (calendarUnit === CALENDAR_UNIT.month) {
+        const [startMoment, endMoment] = getStartAndEndDate(referenceDate);
+
+        referenceDateRange = { startMoment, endMoment };
+      } else if (calendarUnit === CALENDAR_UNIT.week) {
+        referenceDateRange = {
+          startMoment: moment(referenceDate).startOf('week').startOf('day'),
+          endMoment: moment(referenceDate).endOf('week').endOf('day'),
+        };
+      } else if (calendarUnit === CALENDAR_UNIT.days && rangeAmount) {
+        referenceDateRange = {
+          startMoment: moment(referenceDate).startOf('day'),
+          endMoment: moment(referenceDate)
+            .add(rangeAmount - 1, 'day')
+            .endOf('day'),
+        };
+      } else {
+        referenceDateRange = {
+          startMoment: moment(referenceDate).startOf('day'),
+          endMoment: moment(referenceDate).endOf('day'),
+        };
+      }
+
       return {
-        referenceDate: moment(referenceDate).add(1, calendarUnit),
-      };
-    }),
-  decreaseReferenceDate: () =>
-    set(({ referenceDate, calendarUnit }) => {
-      return {
-        referenceDate: moment(referenceDate).subtract(1, calendarUnit),
+        referenceDate,
+        referenceDateRange,
+        calendarUnit,
       };
     }),
 }));

--- a/src/stores/date.ts
+++ b/src/stores/date.ts
@@ -16,28 +16,28 @@ const initialState = {
 } as const;
 
 type TDateAction = {
-  increaseStoreMonth: () => void;
-  decreaseStoreMonth: () => void;
   setReferenceDate: (date: MomentInput) => void;
   setCalendarUnit: (calendarUnit: TCalendarUnit) => void;
+  increaseReferenceDate: () => void;
+  decreaseReferenceDate: () => void;
 };
 
 const useDateState = create<TDateState & TDateAction>((set) => ({
   ...initialState,
-  increaseStoreMonth: () =>
+  setReferenceDate: (date) => set({ referenceDate: moment(date) }),
+  setCalendarUnit: (calendarUnit) => set({ calendarUnit }),
+  increaseReferenceDate: () =>
     set(({ referenceDate, calendarUnit }) => {
       return {
         referenceDate: moment(referenceDate).add(1, calendarUnit),
       };
     }),
-  decreaseStoreMonth: () =>
+  decreaseReferenceDate: () =>
     set(({ referenceDate, calendarUnit }) => {
       return {
         referenceDate: moment(referenceDate).subtract(1, calendarUnit),
       };
     }),
-  setReferenceDate: (date) => set({ referenceDate: moment(date) }),
-  setCalendarUnit: (calendarUnit) => set({ calendarUnit }),
 }));
 
 export default useDateState;

--- a/src/stores/date.ts
+++ b/src/stores/date.ts
@@ -7,12 +7,14 @@ import { TCalendarUnit } from '@/types';
 
 type TDateState = {
   referenceDate: Moment;
+  referenceDateRange: number;
   calendarUnit: TCalendarUnit;
 };
 
 const initialState = {
   referenceDate: moment(),
-  calendarUnit: CALENDAR_UNIT[2],
+  referenceDateRange: 1,
+  calendarUnit: CALENDAR_UNIT.month,
 } as const;
 
 type TDateAction = {

--- a/src/stores/date.ts
+++ b/src/stores/date.ts
@@ -43,9 +43,12 @@ type TDateAction = {
 
 const useDateState = create<TDateState & TDateAction>((set, get) => ({
   ...createInitialState(),
-  setReferenceDate: (referenceDate) =>
-    get().setDateWithRange({ referenceDate }),
-  setCalendarUnit: (calendarUnit) => get().setDateWithRange({ calendarUnit }),
+  setReferenceDate: (referenceDate) => {
+    return get().setDateWithRange({ referenceDate });
+  },
+  setCalendarUnit: (calendarUnit) => {
+    return get().setDateWithRange({ calendarUnit });
+  },
   increaseReferenceDate: () => {
     const { referenceDate: prevDate, calendarUnit, setDateWithRange } = get();
     const referenceDate = moment(prevDate).add(1, calendarUnit);

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -33,7 +33,7 @@ const Template: ComponentStory<typeof CalendarView> = () => {
   }, []);
 
   const referenceDate = useDateState(({ referenceDate }) => referenceDate);
-  const startOfMonth = referenceDate
+  const startOfMonth = moment(referenceDate)
     .startOf('month')
     .startOf('week')
     .startOf('day');

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -29,7 +29,7 @@ const Template: ComponentStory<typeof CalendarView> = () => {
     ({ setCalendarUnit }) => setCalendarUnit,
   );
   useEffect(() => {
-    setCalendarUnit(CALENDAR_UNIT[2]);
+    setCalendarUnit(CALENDAR_UNIT.month);
   }, []);
 
   const referenceDate = useDateState(({ referenceDate }) => referenceDate);

--- a/src/stories/calendars/SmallCalendar.stories.tsx
+++ b/src/stories/calendars/SmallCalendar.stories.tsx
@@ -13,10 +13,11 @@ export default {
   component: MiniCalendar,
   argTypes: {
     selectedCalendarIndex: {
-      options: [0, 1, 2],
+      options: Object.values(CALENDAR_UNIT),
+      mapping: Object.values(CALENDAR_UNIT),
       control: {
         type: 'select',
-        labels: CALENDAR_UNIT,
+        labels: Object.keys(CALENDAR_UNIT),
       },
     },
   },
@@ -28,7 +29,7 @@ const Container = styled.div`
 
 const Template: ComponentStory<
   React.FC<{
-    selectedCalendarIndex: 0 | 1 | 2;
+    selectedCalendarIndex: (typeof CALENDAR_UNIT)[keyof typeof CALENDAR_UNIT];
   }>
 > = ({ selectedCalendarIndex }) => {
   const setCalendarUnit = useDateState(
@@ -48,5 +49,5 @@ const Template: ComponentStory<
 
 export const Primary = Template.bind({});
 Primary.args = {
-  selectedCalendarIndex: 2,
+  selectedCalendarIndex: CALENDAR_UNIT.month,
 };

--- a/src/stories/sidebar/TagClassifier.stories.tsx
+++ b/src/stories/sidebar/TagClassifier.stories.tsx
@@ -18,10 +18,11 @@ export default {
   argTypes: {
     date: { control: 'date', description: '현재 달력에 선택된 날짜입니다.' },
     unit: {
-      options: [0, 1, 2],
+      options: Object.values(CALENDAR_UNIT),
+      mapping: Object.values(CALENDAR_UNIT),
       control: {
         type: 'select',
-        labels: CALENDAR_UNIT,
+        labels: Object.keys(CALENDAR_UNIT),
       },
       description: '현재 달력을 나타내는 단위입니다.',
     },
@@ -30,7 +31,7 @@ export default {
 
 type TArgs = {
   date: number;
-  unit: number;
+  unit: (typeof CALENDAR_UNIT)[keyof typeof CALENDAR_UNIT];
 };
 
 const Template: ComponentStory<
@@ -112,7 +113,7 @@ const TestButton = styled.button`
 export const Tag = Template.bind({});
 Tag.args = {
   date: new Date().getTime(),
-  unit: 2,
+  unit: CALENDAR_UNIT.month,
 };
 Tag.parameters = {
   msw: {

--- a/src/stories/timetable/DayTimetable.stories.tsx
+++ b/src/stories/timetable/DayTimetable.stories.tsx
@@ -20,9 +20,6 @@ import {
 export default {
   title: 'Timetable/DayTimetable',
   component: Timetable,
-  argTypes: {
-    rangeAmount: { control: 'number' },
-  },
 } as ComponentMeta<typeof Timetable>;
 
 const Template: ComponentStory<typeof Timetable> = (args) => {
@@ -122,7 +119,7 @@ const TestButton = styled.button`
 `;
 
 export const Primary = Template.bind({});
-Primary.args = { rangeAmount: 1 };
+Primary.args = {};
 Primary.parameters = {
   msw: {
     handlers: [

--- a/src/stories/timetable/WeekTimetable.stories.tsx
+++ b/src/stories/timetable/WeekTimetable.stories.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import moment from 'moment';
 
 import Timetable from '@/components/home/main/timetable';
+import { CALENDAR_UNIT } from '@/constants';
 import { useCreatePlanMutation } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
@@ -21,21 +22,46 @@ export default {
   title: 'Timetable/WeekTimetable',
   component: Timetable,
   argTypes: {
-    rangeAmount: { control: 'number' },
+    storybookRangeAmount: {
+      name: '선택된 범위',
+      control: {
+        type: 'range',
+        min: 1,
+        max: 7,
+        step: 1,
+      },
+      description: '현재 달력에서 선택된 범위입니다.',
+    },
+    storybookReferenceDate: {
+      name: '선택된 날짜',
+      control: 'date',
+      description: '현재 달력에 선택된 날짜입니다.',
+    },
   },
 } as ComponentMeta<typeof Timetable>;
 
-const Template: ComponentStory<typeof Timetable> = (args) => {
-  const { referenceDate, setCalendarUnit } = useDateState(
-    ({ referenceDate, setCalendarUnit }) => ({
+type TArgs = {
+  storybookRangeAmount: number;
+  storybookReferenceDate: number;
+};
+
+const Template: ComponentStory<
+  (args: TArgs) => ReturnType<typeof Timetable>
+> = ({ storybookReferenceDate, storybookRangeAmount, ...args }) => {
+  const { referenceDate, setDateWithRange } = useDateState(
+    ({ referenceDate, setDateWithRange }) => ({
       referenceDate,
-      setCalendarUnit,
+      setDateWithRange,
     }),
   );
 
   useEffect(() => {
-    setCalendarUnit('week');
-  }, []);
+    setDateWithRange({
+      referenceDate: storybookReferenceDate,
+      calendarUnit: CALENDAR_UNIT.days,
+      rangeAmount: storybookRangeAmount,
+    });
+  }, [storybookRangeAmount, storybookReferenceDate]);
 
   const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
   const queryClient = useQueryClient();
@@ -142,7 +168,10 @@ const TestButton = styled.button`
 `;
 
 export const Primary = Template.bind({});
-Primary.args = { rangeAmount: 7 };
+Primary.args = {
+  storybookReferenceDate: new Date().getTime(),
+  storybookRangeAmount: 7,
+};
 Primary.parameters = {
   msw: {
     handlers: [


### PR DESCRIPTION
- Closes #147

## ✨ **구현 기능 명세**

### 전역 Date 상태에 대한 범위 추가

기존에 달력을 나타내는 방법은, 사용자가 선택한 날짜(`referenceDate`)를 토대로 어떤 형태(`calendarUnit`)로 View를 나타낼 것인지 결정했습니다.
그러다 보니 월, 주 단위를 나타낼 때는 해당 정보를 토대로 View마다 계산하는 로직을 추가해주어야 했습니다.
|기존의 범위 계산|
|:---:|
|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/74603ab8-f503-4152-922f-4a037b8ddace" alt="기존의 범위 계산" width=650 />| 

저는 날짜에 대한 View의 범위 또한 Date 상태의 역할이라고 생각했습니다.
따라서 다음 그림과 같이 현재 사용자가 보고자 하는 날짜에 대한 범위를 **상태가 변경됨에 따라 동시에 계산**하도록 변경했습니다
|범위에 대한 상태 참조|
|:---:|
|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/49eb9f2b-318f-41f5-bf29-947338c2238b" alt="범위에 대한 상태 참조" width=650 />| 

### 달력 형태(CALENDAR_UNIT) 상수 명확히하기

기존에 사용하던 `CALENDAR_UNIT` 상수가 개발 시 어떤 index가 어떤 값을 가지는지 알아보기 힘들어 다음과 같이 변경했습니다.
\+ 2~6일 사이의 Timetable을 사용할 수 있는 'days' 항목을 추가했습니다.

<table>
<tr>
<th> 기존 CALENDAR_UNIT </th>
<th> 변경 CALENDAR_UNIT </th>
</tr>
<tr>
<td>

```typescript
const CALENDAR_UNIT = [
  'day',
  'week',
  'month'
] as const;
```

</td>
<td>

```typescript
const CALENDAR_UNIT = {
  day: 'day',
  days: 'days',
  week: 'week',
  month: 'month',
} as const;
```

</td>
</tr>
</table>


## 🎁 **주목할 점**

### 날짜 범위 안에있는 Plans를 가져오는 Hook

저희 프로젝트는 `React-Query`를 사용하면서 이미 일정을 한달 단위로 캐싱하고 있습니다.
하지만 일, 주, 월 단위로 달력의 일정을 필터링하며 보여주는 과정에서 여러 컴포넌트가 일정 필터링을 거쳐야 하는 상황이 왔습니다.

|두 컴포넌트에서 범위에 대한 일정 필터링|
|:---:|
|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/2eeb3c8a-8b8c-4dbd-8592-13369c74a892" alt="두 컴포넌트에서 범위에 대한 일정 필터링" width=650 />|

문제는 이 필터링 과정이 컴포넌트 안에서 이루어지고 있어 View의 렌더링이 일어날 때마다 작동한다는 것입니다.
서비스의 최적화를 위해 **일정(`plans`)과 날짜(`referenceDateRange`)의 변경에만 필터링 과정을 진행할 수 있도록** `useRangedPlans` 훅을 작성했습니다.

1. 문제 해결 방법 - 필터링 과정 줄이기, useMemo
`useMemo`를 통해 날짜 범위 안에 있는 일정 데이터 필터링을 저장하게 했습니다.
`referenceDateRange`(\+ `referenceDate`, `calendarUnit`)과 일정(`data`)의 변경에만 필터링을 다시 계산합니다.

2. 문제 해결 방법2 - 여러 컴포넌트에서 선언해도 단 한번의 계산
위의 그림을 참고해보면 여러 컴포넌트에서 동일한 필터링을 진행하고 있습니다.
이 과정을 최대한 줄이고 싶어 Closure를 이용해 `useMemo`가 필터링된 배열 메모리 값을 참조하도록 작성했습니다.
해당 값을 처음 계산하는지 아닌지는 `zustand/shallow`를 통해 key 값 비교를 진행하고 있습니다.

|필터링 일정 캐싱 순서도|
|:---:|
|<img src="https://github.com/JiPyoTak/plandar-client/assets/55688122/b1ca34a2-38b1-468d-b590-06ef40978bb4" alt="필터링 일정 캐싱 순서도" width=200 />|
