### PR TITLE
modal open state 생성

### DIFF
--- a/src/components/core/buttons/PlusButton.tsx
+++ b/src/components/core/buttons/PlusButton.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 
 import { PlusIcon } from '@/components/common/icons';
 import StylishButton from '@/components/core/buttons/StylishButton';
+import useModalState from '@/stores/modal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 const PlusButton: React.FC = () => {
   const createNewPlan = useFocusedPlanState((store) => store.createNewPlan);
+  const openModal = useModalState((state) => state.openModal);
+
+  const onClickButton = () => {
+    createNewPlan();
+    openModal();
+  };
 
   return (
     <StylishButton
-      onClick={() => createNewPlan()}
+      onClick={onClickButton}
       size="small"
       isColor={true}
       isSquare={true}

--- a/src/components/core/buttons/PlusButton.tsx
+++ b/src/components/core/buttons/PlusButton.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { PlusIcon } from '@/components/common/icons';
 import StylishButton from '@/components/core/buttons/StylishButton';
-import useModalState from '@/stores/modal';
+import useCreateModalState from '@/stores/modal/create';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 const PlusButton: React.FC = () => {
   const createNewPlan = useFocusedPlanState((store) => store.createNewPlan);
-  const openModal = useModalState((state) => state.openModal);
+  const openModal = useCreateModalState((state) => state.openModal);
 
   const onClickButton = () => {
     createNewPlan();

--- a/src/components/modal/plan/create/index.tsx
+++ b/src/components/modal/plan/create/index.tsx
@@ -19,6 +19,7 @@ import {
   useCreatePlanMutation,
   useUpdatePlanMutation,
 } from '@/hooks/query/plan';
+import useModalState from '@/stores/modal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import { ColorCircle } from '@/styles/category';
 
@@ -35,17 +36,23 @@ const CreatePlanModal: TCreatePlanModal = ({
   onClose,
   onDone,
 }: TCreatePlanModalProps) => {
-  const { focusedPlan, openModal, clearPlan, isDisabled, isEdit } =
-    useFocusedPlanState(
-      ({ focusedPlan, isDragging, clearDraggedPlan, type }) => ({
-        focusedPlan,
-        openModal: initOpenModal || (!isDragging && !!focusedPlan),
-        clearPlan: clearDraggedPlan,
-        isDisabled: !focusedPlan?.startTime || !focusedPlan?.endTime,
-        isEdit: type === 'edit',
-      }),
-      shallow,
-    );
+  const { focusedPlan, isDisabled, isEdit, clearPlan } = useFocusedPlanState(
+    ({ focusedPlan, clearDraggedPlan, type }) => ({
+      focusedPlan,
+      isEdit: type === 'edit',
+      isDisabled: !focusedPlan?.startTime || !focusedPlan?.endTime,
+      clearPlan: clearDraggedPlan,
+    }),
+    shallow,
+  );
+
+  const [isOpen, closeModal] = useModalState(
+    (state) => {
+      return [(initOpenModal || state.isOpen) && focusedPlan, state.closeModal];
+    },
+    (prev, cur) => prev === cur,
+  );
+
   const { mutateAsync: createMutate } = useCreatePlanMutation();
   const { mutateAsync: updateMutate } = useUpdatePlanMutation();
   const category = useCategoryQuery();
@@ -53,6 +60,7 @@ const CreatePlanModal: TCreatePlanModal = ({
   const onCloseHandler = () => {
     onClose?.();
     clearPlan();
+    closeModal();
   };
 
   const onSubmit = async () => {
@@ -89,7 +97,7 @@ const CreatePlanModal: TCreatePlanModal = ({
     }
   };
 
-  if (!openModal) {
+  if (!isOpen) {
     return null;
   }
 

--- a/src/components/modal/plan/create/index.tsx
+++ b/src/components/modal/plan/create/index.tsx
@@ -19,7 +19,7 @@ import {
   useCreatePlanMutation,
   useUpdatePlanMutation,
 } from '@/hooks/query/plan';
-import useModalState from '@/stores/modal';
+import useCreateModalState from '@/stores/modal/create';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import { ColorCircle } from '@/styles/category';
 
@@ -46,7 +46,7 @@ const CreatePlanModal: TCreatePlanModal = ({
     shallow,
   );
 
-  const [isOpen, closeModal] = useModalState(
+  const [isOpen, closeModal] = useCreateModalState(
     (state) => {
       return [(initOpenModal || state.isOpen) && focusedPlan, state.closeModal];
     },

--- a/src/components/modal/plan/select/index.tsx
+++ b/src/components/modal/plan/select/index.tsx
@@ -11,6 +11,7 @@ import ModalContainer from '@/components/modal/ModalPortal';
 import { toast } from '@/core/toast';
 import { useDeletePlanMutation } from '@/hooks/query/plan';
 import { useEffectModal } from '@/hooks/useEffectModal';
+import useModalState from '@/stores/modal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import useSelectedPlanState from '@/stores/plan/selectedPlan';
 import { FONT_REGULAR_5 } from '@/styles/font';
@@ -19,6 +20,7 @@ const SelectedPlanModal = () => {
   const { mutate } = useDeletePlanMutation();
 
   const editDragPlan = useFocusedPlanState((state) => state.editDragPlan);
+  const openModal = useModalState((state) => state.openModal);
 
   const { dom, initialPlan, clearSelectedPlan } = useSelectedPlanState(
     (state) => ({
@@ -80,6 +82,7 @@ const SelectedPlanModal = () => {
 
   const editPlan = () => {
     editDragPlan(plan);
+    openModal();
     clearSelectedPlan();
   };
 

--- a/src/components/modal/plan/select/index.tsx
+++ b/src/components/modal/plan/select/index.tsx
@@ -11,7 +11,7 @@ import ModalContainer from '@/components/modal/ModalPortal';
 import { toast } from '@/core/toast';
 import { useDeletePlanMutation } from '@/hooks/query/plan';
 import { useEffectModal } from '@/hooks/useEffectModal';
-import useModalState from '@/stores/modal';
+import useCreateModalState from '@/stores/modal/create';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import useSelectedPlanState from '@/stores/plan/selectedPlan';
 import { FONT_REGULAR_5 } from '@/styles/font';
@@ -20,7 +20,7 @@ const SelectedPlanModal = () => {
   const { mutate } = useDeletePlanMutation();
 
   const editDragPlan = useFocusedPlanState((state) => state.editDragPlan);
-  const openModal = useModalState((state) => state.openModal);
+  const openModal = useCreateModalState((state) => state.openModal);
 
   const { dom, initialPlan, clearSelectedPlan } = useSelectedPlanState(
     (state) => ({

--- a/src/hooks/usePlanDrag.ts
+++ b/src/hooks/usePlanDrag.ts
@@ -4,6 +4,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useUpdatePlanMutation } from './query/plan';
 import { toast } from '@/core/toast';
+import useModalState from '@/stores/modal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 export type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>;
@@ -27,6 +28,9 @@ const usePlanDrag = () => {
     }),
     shallow,
   );
+
+  const openModal = useModalState((state) => state.openModal);
+
   const currentDateRef = useRef<string | null>(null);
   const draggingDateRef = useRef<string | null>(null);
   const focusedPlanRef = useRef<typeof focusedPlan>(focusedPlan);
@@ -109,9 +113,14 @@ const usePlanDrag = () => {
         toast(`${focusedPlan.title} 일정 날짜가 변경되었습니다`);
       }
 
+      if (focusedPlan.id === -1) {
+        openModal();
+      }
+
       timeTypeRef.current = null;
       currentDateRef.current = null;
       draggingDateRef.current = null;
+
       onDragEndPlan();
     };
 

--- a/src/hooks/usePlanDrag.ts
+++ b/src/hooks/usePlanDrag.ts
@@ -4,7 +4,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useUpdatePlanMutation } from './query/plan';
 import { toast } from '@/core/toast';
-import useModalState from '@/stores/modal';
+import useCreateModalState from '@/stores/modal/create';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 export type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>;
@@ -29,7 +29,7 @@ const usePlanDrag = () => {
     shallow,
   );
 
-  const openModal = useModalState((state) => state.openModal);
+  const openModal = useCreateModalState((state) => state.openModal);
 
   const currentDateRef = useRef<string | null>(null);
   const draggingDateRef = useRef<string | null>(null);

--- a/src/stores/modal/create.ts
+++ b/src/stores/modal/create.ts
@@ -13,7 +13,7 @@ const initialState: IModalState = {
   isOpen: false,
 } as const;
 
-const useModalState = create<IModalState & IModalAction>((set) => ({
+const useCreateModalState = create<IModalState & IModalAction>((set) => ({
   ...initialState,
   openModal: () => {
     set({ isOpen: true });
@@ -23,4 +23,4 @@ const useModalState = create<IModalState & IModalAction>((set) => ({
   },
 }));
 
-export default useModalState;
+export default useCreateModalState;

--- a/src/stores/modal/index.ts
+++ b/src/stores/modal/index.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+interface IModalState {
+  isOpen: boolean;
+}
+
+interface IModalAction {
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+const initialState: IModalState = {
+  isOpen: false,
+} as const;
+
+const useModalState = create<IModalState & IModalAction>((set) => ({
+  ...initialState,
+  openModal: () => {
+    set({ isOpen: true });
+  },
+  closeModal: () => {
+    set({ isOpen: false });
+  },
+}));
+
+export default useModalState;

--- a/src/stores/plan/focusedPlan.ts
+++ b/src/stores/plan/focusedPlan.ts
@@ -145,10 +145,7 @@ const useFocusedPlanState = create<IFocusedPlanState & IFocusedPlanAction>(
       set(initialState);
     },
     createNewPlan: (planData) => {
-      const newPlan = createInitPlan({
-        title: '',
-        ...planData,
-      });
+      const newPlan = createInitPlan(planData);
 
       set((state) => ({
         ...state,

--- a/src/utils/plan/createInitPlan.ts
+++ b/src/utils/plan/createInitPlan.ts
@@ -2,7 +2,7 @@ import Plan from '@/core/plan/Plan';
 import { theme } from '@/styles/theme';
 import { IPlan } from '@/types/query/plan';
 
-const createInitPlan = (planData: Partial<IPlan>) => {
+const createInitPlan = (planData: Partial<IPlan> = {}) => {
   const newPlan = new Plan({
     id: -1,
     title: '새로운 일정',


### PR DESCRIPTION
- Closes #165

## ✨ **구현 기능 명세**
- 기존 focusedPlan 내부의 isDragging을 통해 판단하던 modal open 여부를 useModalState를 통해 제어하도록 변경합니다.

## 🎁 **주목할 점**

기존 create modal은 렌더링을 위해서 드래그 여부를 통해 판단하고 있습니다.

하지만 드래그가 종료되었을때 다른 기능이 실행되어야 하는 경우 create modal이 렌더링되기 때문에 문제가 발생하였습니다.

이를 위해  modal을 위한 전역 상태를 생성하여 modal open여부를 제어할 수 있도록 변경합니다.