### PR TITLE
React Query 코드 컨벤션 통일화 및 일부 버그 수정

### DIFF
--- a/src/components/home/main/timetable/view/columns/TimetableSelected.tsx
+++ b/src/components/home/main/timetable/view/columns/TimetableSelected.tsx
@@ -13,7 +13,6 @@ const TimetableSelected: React.FC = () => {
       focusedPlan,
     }),
   );
-
   if (!focusedPlan || !focusedPlan.isTimePlan) return <></>;
 
   const isPlanInRange = viewMoment.isBetween(
@@ -24,7 +23,8 @@ const TimetableSelected: React.FC = () => {
   );
   const isPlanUnedited =
     currentPlan?.startMoment.isSame(focusedPlan.startMoment) &&
-    currentPlan?.endMoment.isSame(focusedPlan.endMoment);
+    currentPlan?.endMoment.isSame(focusedPlan.endMoment) &&
+    currentPlan?.id !== -1;
   if (!isPlanInRange || isPlanUnedited) return <></>;
 
   const manager = new TimePlanManager([focusedPlan], viewMoment);

--- a/src/components/modal/category/index.tsx
+++ b/src/components/modal/category/index.tsx
@@ -10,10 +10,10 @@ import ModalContainer from '@/components/modal/ModalPortal';
 import { SELECTABLE_COLOR } from '@/constants';
 import { toast } from '@/core/toast';
 import {
-  useCategoryCreate,
-  useCategoryDelete,
+  useCreateCategory,
+  useDeleteCategory,
   useCategoryQuery,
-  useCategoryUpdate,
+  useUpdateCategory,
 } from '@/hooks/query/category';
 import useCategoryModalState from '@/stores/modal/category';
 import { ColorCircle } from '@/styles/category';
@@ -41,9 +41,9 @@ const CategoryModalViewer: React.FC<object> = () => {
 
   const originalCategory = useCategoryQuery({ id });
   const { data: categoryData } = useCategoryQuery();
-  const { mutate: createCategory } = useCategoryCreate();
-  const { mutate: updateCategory } = useCategoryUpdate();
-  const { mutate: deleteCategory } = useCategoryDelete();
+  const { mutate: createCategory } = useCreateCategory();
+  const { mutate: updateCategory } = useUpdateCategory();
+  const { mutate: deleteCategory } = useDeleteCategory();
 
   const [newName, setNewName] = useState<string>(
     originalCategory?.name ?? DEFAULT_NAME,

--- a/src/components/modal/plan/create/category/CategoryCreateForm.tsx
+++ b/src/components/modal/plan/create/category/CategoryCreateForm.tsx
@@ -3,7 +3,7 @@ import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { SELECTABLE_COLOR } from '@/constants';
-import { useCategoryCreate } from '@/hooks/query/category';
+import { useCreateCategory } from '@/hooks/query/category';
 import { FONT_REGULAR_3 } from '@/styles/font';
 import { ICategory } from '@/types/query/category';
 
@@ -20,7 +20,7 @@ const CategoryCreateForm: TCategoryCreate = ({
 }: TCategoryCreateProps) => {
   const [error, setError] = useState('');
   const loadingRef = useRef(false);
-  const { mutateAsync: createCategory } = useCategoryCreate();
+  const { mutateAsync: createCategory } = useCreateCategory();
   const newCategoryName = name.trim();
 
   const onMouseDown = async () => {

--- a/src/components/modal/plan/create/category/SelectedCategoryDisplay.tsx
+++ b/src/components/modal/plan/create/category/SelectedCategoryDisplay.tsx
@@ -8,7 +8,7 @@ import PickButton from '@/components/common/color-picker/PickButton';
 import ModalBackground from '@/components/common/modal/ModalBackground';
 import { toast } from '@/core/toast';
 import useModalPopupPosition from '@/hooks/modal/useModalPopupPositon';
-import { useCategoryUpdate } from '@/hooks/query/category';
+import { useUpdateCategory } from '@/hooks/query/category';
 import { ColorCircle } from '@/styles/category';
 import {
   ClassifierAdditionalFontStyle,
@@ -31,7 +31,7 @@ const SelectedCategoryDisplay: TSelectedCategoryDisplay = ({
   const theme = useTheme();
   const [popupOpened, setPopupOpened] = useState(false);
 
-  const { mutateAsync: updateCategory } = useCategoryUpdate();
+  const { mutateAsync: updateCategory } = useUpdateCategory();
   const { positionTopRef, setPositionTop } = useModalPopupPosition();
 
   const onSelect = async (newColor: TColor) => {

--- a/src/components/modal/plan/create/index.tsx
+++ b/src/components/modal/plan/create/index.tsx
@@ -15,10 +15,7 @@ import PlanTag from '@/components/modal/plan/create/PlanTag';
 import PlanTitleInput from '@/components/modal/plan/create/PlanTitleInput';
 import { toast } from '@/core/toast';
 import { useCategoryQuery } from '@/hooks/query/category';
-import {
-  useCreatePlanMutation,
-  useUpdatePlanMutation,
-} from '@/hooks/query/plan';
+import { useCreatePlan, useUpdatePlan } from '@/hooks/query/plan';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import { ColorCircle } from '@/styles/category';
 
@@ -46,8 +43,8 @@ const CreatePlanModal: TCreatePlanModal = ({
       }),
       shallow,
     );
-  const { mutateAsync: createMutate } = useCreatePlanMutation();
-  const { mutateAsync: updateMutate } = useUpdatePlanMutation();
+  const { mutateAsync: createMutate } = useCreatePlan();
+  const { mutateAsync: updateMutate } = useUpdatePlan();
   const category = useCategoryQuery();
 
   const onCloseHandler = () => {

--- a/src/components/modal/plan/select/index.tsx
+++ b/src/components/modal/plan/select/index.tsx
@@ -9,14 +9,14 @@ import TimeStamp from '@/components/common/modal/Timestamp';
 import TagButton from '@/components/core/buttons/TagButton';
 import ModalContainer from '@/components/modal/ModalPortal';
 import { toast } from '@/core/toast';
-import { useDeletePlanMutation } from '@/hooks/query/plan';
+import { useDeletePlan } from '@/hooks/query/plan';
 import { useEffectModal } from '@/hooks/useEffectModal';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 import useSelectedPlanState from '@/stores/plan/selectedPlan';
 import { FONT_REGULAR_5 } from '@/styles/font';
 
 const SelectedPlanModal = () => {
-  const { mutate } = useDeletePlanMutation();
+  const { mutate } = useDeletePlan();
 
   const editDragPlan = useFocusedPlanState((state) => state.editDragPlan);
 

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,0 +1,7 @@
+enum QUERY_KEY {
+  CATEGORY_KEY = 'category',
+  PLAN_KEY = 'plan',
+  MONTH_PLAN_KEY = 'plans',
+}
+
+export { QUERY_KEY };

--- a/src/constants/rqKeys.ts
+++ b/src/constants/rqKeys.ts
@@ -1,3 +1,0 @@
-const CATEGORY_KEY = 'category';
-
-export { CATEGORY_KEY };

--- a/src/hooks/query/category.ts
+++ b/src/hooks/query/category.ts
@@ -42,9 +42,9 @@ function useCategoryQuery(props?: { id?: number | null }) {
 }
 
 // 카테고리 추가
+let tempId = 0;
 const useCreateCategory = () => {
   const queryClient = useQueryClient();
-  let id = 0;
 
   return useMutation(
     // api 호출
@@ -59,11 +59,11 @@ const useCreateCategory = () => {
         // 낙관적 업데이트를 위한 새로운 데이터 캐싱
         queryClient.setQueryData<ICategory[]>(
           [QUERY_KEY.CATEGORY_KEY],
-          (old) => [...(old ?? []), { ...newCategory, id: --id }],
+          (old) => [...(old ?? []), { ...newCategory, id: --tempId }],
         );
 
         // onError의 context에 들어갈 값
-        return { previousCategories, id };
+        return { previousCategories, id: tempId };
       },
       // 에러 발생시 원래 캐싱된 데이터로 복구
       onError: (err, newCategory, context) => {

--- a/src/hooks/query/category.ts
+++ b/src/hooks/query/category.ts
@@ -39,7 +39,7 @@ function useCategoryQuery(props?: { id?: number | null }) {
 }
 
 // 카테고리 추가
-const useCategoryCreate = () => {
+const useCreateCategory = () => {
   const queryClient = useQueryClient();
   let id = 0;
 
@@ -83,7 +83,7 @@ const useCategoryCreate = () => {
   );
 };
 
-const useCategoryUpdate = () => {
+const useUpdateCategory = () => {
   const queryClient = useQueryClient();
 
   return useMutation(
@@ -134,7 +134,7 @@ const useCategoryUpdate = () => {
   );
 };
 
-const useCategoryDelete = () => {
+const useDeleteCategory = () => {
   const queryClient = useQueryClient();
 
   return useMutation(
@@ -181,7 +181,7 @@ const useCategoryDelete = () => {
 
 export {
   useCategoryQuery,
-  useCategoryUpdate,
-  useCategoryCreate,
-  useCategoryDelete,
+  useUpdateCategory,
+  useCreateCategory,
+  useDeleteCategory,
 };

--- a/src/hooks/query/category.ts
+++ b/src/hooks/query/category.ts
@@ -11,7 +11,7 @@ import {
   getCategoryAPI,
   updateCategoryAPI,
 } from '@/apis/category';
-import { CATEGORY_KEY } from '@/constants/rqKeys';
+import { QUERY_KEY } from '@/constants/queryKey';
 import { ICategory, ICategoryWithoutId } from '@/types/query/category';
 
 function useCategoryQuery(): UseQueryResult<ICategory[], unknown>;
@@ -20,12 +20,12 @@ function useCategoryQuery(props?: { id?: number | null }) {
   const queryClient = useQueryClient();
 
   if (!props) {
-    return useQuery<ICategory[]>([CATEGORY_KEY], getCategoryAPI, {
+    return useQuery<ICategory[]>([QUERY_KEY.CATEGORY_KEY], getCategoryAPI, {
       staleTime: 1000 * 60 * 60 * 24,
       onSuccess(data) {
         data.forEach((category) => {
           queryClient.setQueryData(
-            [CATEGORY_KEY, { id: category.id }],
+            [QUERY_KEY.CATEGORY_KEY, { id: category.id }],
             category,
           );
         });
@@ -35,7 +35,10 @@ function useCategoryQuery(props?: { id?: number | null }) {
 
   const { id } = props;
 
-  return queryClient.getQueryData<ICategory>([CATEGORY_KEY, { id }]) ?? null;
+  return (
+    queryClient.getQueryData<ICategory>([QUERY_KEY.CATEGORY_KEY, { id }]) ??
+    null
+  );
 }
 
 // 카테고리 추가
@@ -50,14 +53,14 @@ const useCreateCategory = () => {
       onMutate: async (newCategory: ICategoryWithoutId) => {
         // 실패했을 때 복구를 위한 기존 캐시 데이터 가져오기
         const previousCategories = queryClient.getQueryData<ICategory[]>([
-          CATEGORY_KEY,
+          QUERY_KEY.CATEGORY_KEY,
         ]);
 
         // 낙관적 업데이트를 위한 새로운 데이터 캐싱
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (old) => [
-          ...(old ?? []),
-          { ...newCategory, id: --id },
-        ]);
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (old) => [...(old ?? []), { ...newCategory, id: --id }],
+        );
 
         // onError의 context에 들어갈 값
         return { previousCategories, id };
@@ -65,19 +68,25 @@ const useCreateCategory = () => {
       // 에러 발생시 원래 캐싱된 데이터로 복구
       onError: (err, newCategory, context) => {
         queryClient.setQueryData<ICategory[]>(
-          [CATEGORY_KEY],
+          [QUERY_KEY.CATEGORY_KEY],
           context?.previousCategories ?? [],
         );
       },
       onSuccess: (data, _, context) => {
-        queryClient.setQueryData([CATEGORY_KEY, { id: data.id }], data);
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (oldData) => {
-          return [
-            ...(oldData?.filter((category) => category.id !== context?.id) ??
-              []),
-            data,
-          ];
-        });
+        queryClient.setQueryData(
+          [QUERY_KEY.CATEGORY_KEY, { id: data.id }],
+          data,
+        );
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (oldData) => {
+            return [
+              ...(oldData?.filter((category) => category.id !== context?.id) ??
+                []),
+              data,
+            ];
+          },
+        );
       },
     },
   );
@@ -94,21 +103,24 @@ const useUpdateCategory = () => {
         const id = newCategory.id;
         // 실패했을 때 복구를 위한 기존 캐시 데이터 가져오기
         const previousCategory = queryClient.getQueryData<ICategory>([
-          CATEGORY_KEY,
+          QUERY_KEY.CATEGORY_KEY,
           { id },
         ]);
 
         // 낙관적 업데이트를 위한 새로운 데이터 캐싱
-        queryClient.setQueryData([CATEGORY_KEY, { id }], newCategory);
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (old) => {
-          const newCategories = [...(old ?? [])];
-          const index = newCategories.findIndex(
-            (category) => category.id === newCategory.id,
-          );
-          newCategories[index] = newCategory;
+        queryClient.setQueryData([QUERY_KEY.CATEGORY_KEY, { id }], newCategory);
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (old) => {
+            const newCategories = [...(old ?? [])];
+            const index = newCategories.findIndex(
+              (category) => category.id === newCategory.id,
+            );
+            newCategories[index] = newCategory;
 
-          return newCategories;
-        });
+            return newCategories;
+          },
+        );
 
         // onError의 context에 들어갈 값
         return { previousCategory };
@@ -119,16 +131,22 @@ const useUpdateCategory = () => {
         if (!previousCategory) return;
 
         const id = previousCategory.id;
-        queryClient.setQueryData([CATEGORY_KEY, { id }], previousCategory);
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (old) => {
-          const previousCategories = [...(old ?? [])];
-          const index = previousCategories.findIndex(
-            (category) => category.id === newCategory.id,
-          );
-          previousCategories[index] = previousCategory;
+        queryClient.setQueryData(
+          [QUERY_KEY.CATEGORY_KEY, { id }],
+          previousCategory,
+        );
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (old) => {
+            const previousCategories = [...(old ?? [])];
+            const index = previousCategories.findIndex(
+              (category) => category.id === newCategory.id,
+            );
+            previousCategories[index] = previousCategory;
 
-          return previousCategories;
-        });
+            return previousCategories;
+          },
+        );
       },
     },
   );
@@ -146,19 +164,22 @@ const useDeleteCategory = () => {
 
         // 실패했을 때 복구를 위한 기존 캐시 데이터 가져오기
         const previousCategory = queryClient.getQueryData<ICategory>([
-          CATEGORY_KEY,
+          QUERY_KEY.CATEGORY_KEY,
           { id },
         ]);
 
         // 낙관적 업데이트를 위한 새로운 데이터 캐싱
-        queryClient.removeQueries([CATEGORY_KEY, { id }]);
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (old) => {
-          const newCategories = [...(old ?? [])];
+        queryClient.removeQueries([QUERY_KEY.CATEGORY_KEY, { id }]);
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (old) => {
+            const newCategories = [...(old ?? [])];
 
-          return newCategories.filter(
-            (category) => category.id !== targetCategory.id,
-          );
-        });
+            return newCategories.filter(
+              (category) => category.id !== targetCategory.id,
+            );
+          },
+        );
 
         // onError의 context에 들어갈 값
         return { previousCategory };
@@ -169,11 +190,14 @@ const useDeleteCategory = () => {
         if (!previousCategory) return;
 
         const id = previousCategory.id;
-        queryClient.setQueryData([CATEGORY_KEY, { id }], previousCategory);
-        queryClient.setQueryData<ICategory[]>([CATEGORY_KEY], (old) => [
-          ...(old ?? []),
+        queryClient.setQueryData(
+          [QUERY_KEY.CATEGORY_KEY, { id }],
           previousCategory,
-        ]);
+        );
+        queryClient.setQueryData<ICategory[]>(
+          [QUERY_KEY.CATEGORY_KEY],
+          (old) => [...(old ?? []), previousCategory],
+        );
       },
     },
   );

--- a/src/hooks/query/plan.ts
+++ b/src/hooks/query/plan.ts
@@ -14,6 +14,7 @@ import {
   updatePlanApi,
 } from '@/apis/plan';
 
+import { QUERY_KEY } from '@/constants/queryKey';
 import Plan from '@/core/plan/Plan';
 import { IPlan, TPlanInput } from '@/types/query/plan';
 import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
@@ -54,7 +55,7 @@ const executeCallbackByDate = (
 const addQueriesData =
   (data: IPlan, queryClient: QueryClient) =>
   (timemin: string, timemax: string) => {
-    const key = ['plans', { timemin, timemax }];
+    const key = [QUERY_KEY.MONTH_PLAN_KEY, { timemin, timemax }];
 
     const prevData = queryClient.getQueryData<IPlan[] | undefined>(key);
 
@@ -68,7 +69,7 @@ const addQueriesData =
 const removeQueriesData =
   (id: number, queryClient: QueryClient) =>
   (timemin: string, timemax: string) => {
-    const key = ['plans', { timemin, timemax }];
+    const key = [QUERY_KEY.MONTH_PLAN_KEY, { timemin, timemax }];
 
     const prevData = queryClient.getQueryData<IPlan[] | undefined>(key);
 
@@ -85,13 +86,16 @@ const usePlanQuery = ({ timemin, timemax }: IGetPlansPayload) => {
   const queryClient = useQueryClient();
 
   return useQuery<IPlan[]>(
-    ['plans', { timemin, timemax }],
+    [QUERY_KEY.MONTH_PLAN_KEY, { timemin, timemax }],
     () => getPlansApi({ timemin, timemax }),
     {
       staleTime: 1000 * 60 * 60 * 24,
       onSuccess(data) {
         data.forEach((plan) =>
-          queryClient.setQueryData(['plan', { id: plan.id }], new Plan(plan)),
+          queryClient.setQueryData(
+            [QUERY_KEY.PLAN_KEY, { id: plan.id }],
+            new Plan(plan),
+          ),
         );
       },
     },
@@ -109,7 +113,10 @@ const useCreatePlan = () => {
       const callback = addQueriesData(data, queryClient);
 
       executeCallbackByDate(startTime, endTime, callback);
-      queryClient.setQueryData(['plan', { id: data.id }], new Plan(data));
+      queryClient.setQueryData(
+        [QUERY_KEY.PLAN_KEY, { id: data.id }],
+        new Plan(data),
+      );
     },
   });
 };
@@ -121,7 +128,10 @@ const useUpdatePlan = () => {
   return useMutation<IPlan, unknown, TPlanInput>(updatePlanApi, {
     onSuccess(data, variables) {
       // 기존 일정을 제거
-      const prev = queryClient.getQueryData<Plan>(['plan', { id: data.id }]);
+      const prev = queryClient.getQueryData<Plan>([
+        QUERY_KEY.PLAN_KEY,
+        { id: data.id },
+      ]);
 
       if (!prev) return;
 
@@ -138,7 +148,10 @@ const useUpdatePlan = () => {
 
       executeCallbackByDate(newStartTime, newEndTime, cbByAdd);
 
-      queryClient.setQueryData(['plan', { id: data.id }], new Plan(data));
+      queryClient.setQueryData(
+        [QUERY_KEY.PLAN_KEY, { id: data.id }],
+        new Plan(data),
+      );
     },
   });
 };
@@ -153,7 +166,7 @@ const useDeletePlan = () => {
       const callback = removeQueriesData(variables, queryClient);
 
       executeCallbackByDate(startTime, endTime, callback);
-      queryClient.removeQueries(['plan', { id: data.id }]);
+      queryClient.removeQueries([QUERY_KEY.PLAN_KEY, { id: data.id }]);
     },
   });
 };

--- a/src/hooks/query/plan.ts
+++ b/src/hooks/query/plan.ts
@@ -81,7 +81,7 @@ const removeQueriesData =
     });
   };
 
-const useGetPlansQuery = ({ timemin, timemax }: IGetPlansPayload) => {
+const usePlanQuery = ({ timemin, timemax }: IGetPlansPayload) => {
   const queryClient = useQueryClient();
 
   return useQuery<IPlan[]>(
@@ -99,7 +99,7 @@ const useGetPlansQuery = ({ timemin, timemax }: IGetPlansPayload) => {
 };
 
 // 해당 요청 성공시 캐시 업데이트
-const useCreatePlanMutation = () => {
+const useCreatePlan = () => {
   const queryClient = useQueryClient();
 
   return useMutation<IPlan, unknown, TPlanInput>(createPlanApi, {
@@ -115,7 +115,7 @@ const useCreatePlanMutation = () => {
 };
 
 // 기존 존재하던 일정을 제거하고 변경된 일정을 추가
-const useUpdatePlanMutation = () => {
+const useUpdatePlan = () => {
   const queryClient = useQueryClient();
 
   return useMutation<IPlan, unknown, TPlanInput>(updatePlanApi, {
@@ -143,7 +143,7 @@ const useUpdatePlanMutation = () => {
   });
 };
 
-const useDeletePlanMutation = () => {
+const useDeletePlan = () => {
   const queryClient = useQueryClient();
 
   return useMutation<IPlan, unknown, number>(deletePlanApi, {
@@ -158,9 +158,4 @@ const useDeletePlanMutation = () => {
   });
 };
 
-export {
-  useGetPlansQuery,
-  useCreatePlanMutation,
-  useUpdatePlanMutation,
-  useDeletePlanMutation,
-};
+export { usePlanQuery, useCreatePlan, useUpdatePlan, useDeletePlan };

--- a/src/hooks/usePlanDrag.ts
+++ b/src/hooks/usePlanDrag.ts
@@ -2,14 +2,14 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { shallow } from 'zustand/shallow';
 
-import { useUpdatePlanMutation } from './query/plan';
+import { useUpdatePlan } from './query/plan';
 import { toast } from '@/core/toast';
 import useFocusedPlanState from '@/stores/plan/focusedPlan';
 
 export type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>;
 
 const usePlanDrag = () => {
-  const { mutateAsync } = useUpdatePlanMutation();
+  const { mutateAsync } = useUpdatePlan();
 
   const {
     currentPlan,

--- a/src/hooks/useRangedPlans.ts
+++ b/src/hooks/useRangedPlans.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { shallow } from 'zustand/shallow';
 
-import { useGetPlansQuery } from '@/hooks/query/plan';
+import { usePlanQuery } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import { IPlan } from '@/types/query/plan';
 import { getStartAndEndDate } from '@/utils/date/getStartAndEndDate';
@@ -21,7 +21,7 @@ const useRangedPlans = (function () {
     );
     const [startDate, endDate] = getStartAndEndDate(referenceDate);
 
-    const { data, ...rest } = useGetPlansQuery({
+    const { data, ...rest } = usePlanQuery({
       timemin: startDate.format(),
       timemax: endDate.format(),
     });

--- a/src/stories/calendars/LargeCalendar.stories.tsx
+++ b/src/stories/calendars/LargeCalendar.stories.tsx
@@ -9,7 +9,7 @@ import moment from 'moment';
 import CalendarView from '@/components/home/main/calendar';
 import CalendarHeader from '@/components/home/main/header';
 import { CALENDAR_UNIT } from '@/constants';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
 import {
@@ -37,7 +37,7 @@ const Template: ComponentStory<typeof CalendarView> = () => {
     .startOf('month')
     .startOf('week')
     .startOf('day');
-  const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createMutateAsync } = useCreatePlan();
   const queryClient = useQueryClient();
   const forceUpdate = useReducer(() => ({}), {})[1];
 

--- a/src/stories/sidebar/CategoryClassifier.stories.tsx
+++ b/src/stories/sidebar/CategoryClassifier.stories.tsx
@@ -6,8 +6,8 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import CategoryClassifier from '@/components/home/sidebar/content/classifier/category';
-import { useCategoryCreate, useCategoryQuery } from '@/hooks/query/category';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreateCategory, useCategoryQuery } from '@/hooks/query/category';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useClassifiedPlans from '@/hooks/useClassifiedPlans';
 import useDateState from '@/stores/date';
 import {
@@ -28,8 +28,8 @@ export default {
 const Template: ComponentStory<typeof CategoryClassifier> = () => {
   const referenceDate = useDateState(({ referenceDate }) => referenceDate);
   const plans = useClassifiedPlans();
-  const { mutateAsync: createCategoryMutateAsync } = useCategoryCreate();
-  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createCategoryMutateAsync } = useCreateCategory();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlan();
   const queryClient = useQueryClient();
   const forceUpdate = useReducer(() => ({}), {})[1];
 

--- a/src/stories/sidebar/TagClassifier.stories.tsx
+++ b/src/stories/sidebar/TagClassifier.stories.tsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 
 import TagClassifier from '@/components/home/sidebar/content/classifier/TagClassifier';
 import { CALENDAR_UNIT } from '@/constants';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
 import { createPlanApiHandler, getPlansApiHandler } from '@/stories/apis/plan';
@@ -44,7 +44,7 @@ const Template: ComponentStory<
       setCalendarUnit,
     }),
   );
-  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlan();
 
   useLayoutEffect(() => {
     setReferenceDate(moment(dateTime));

--- a/src/stories/sidebar/TypeClassifier.stories.tsx
+++ b/src/stories/sidebar/TypeClassifier.stories.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import TypeClassifier from '@/components/home/sidebar/content/classifier/TypeClassifier';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useClassifiedPlans from '@/hooks/useClassifiedPlans';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
@@ -17,7 +17,7 @@ export default {
 
 const Template: ComponentStory<typeof TypeClassifier> = (args) => {
   const referenceDate = useDateState(({ referenceDate }) => referenceDate);
-  const { mutateAsync: createPlanMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createPlanMutateAsync } = useCreatePlan();
   const plans = useClassifiedPlans();
 
   const typePlans = {

--- a/src/stories/timetable/DayTimetable.stories.tsx
+++ b/src/stories/timetable/DayTimetable.stories.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import moment from 'moment';
 
 import Timetable from '@/components/home/main/timetable';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
 import {
@@ -34,7 +34,7 @@ const Template: ComponentStory<typeof Timetable> = (args) => {
     setCalendarUnit('day');
   }, []);
 
-  const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createMutateAsync } = useCreatePlan();
   const queryClient = useQueryClient();
   const forceUpdate = useReducer(() => ({}), {})[1];
 

--- a/src/stories/timetable/WeekTimetable.stories.tsx
+++ b/src/stories/timetable/WeekTimetable.stories.tsx
@@ -8,7 +8,7 @@ import moment from 'moment';
 
 import Timetable from '@/components/home/main/timetable';
 import { CALENDAR_UNIT } from '@/constants';
-import { useCreatePlanMutation } from '@/hooks/query/plan';
+import { useCreatePlan } from '@/hooks/query/plan';
 import useDateState from '@/stores/date';
 import planStubManager from '@/stories/apis/data/plan';
 import {
@@ -63,7 +63,7 @@ const Template: ComponentStory<
     });
   }, [storybookRangeAmount, storybookReferenceDate]);
 
-  const { mutateAsync: createMutateAsync } = useCreatePlanMutation();
+  const { mutateAsync: createMutateAsync } = useCreatePlan();
   const queryClient = useQueryClient();
   const forceUpdate = useReducer(() => ({}), {})[1];
 

--- a/src/utils/plan/createInitPlan.ts
+++ b/src/utils/plan/createInitPlan.ts
@@ -18,9 +18,13 @@ const createInitPlan = (planData: Partial<IPlan>) => {
   });
   if (!planData.startTime) {
     newPlan._startTime = Date.now();
+  } else {
+    newPlan._startTime = newPlan.startTime;
   }
   if (!planData.endTime) {
     newPlan._endTime = Date.now() + 1000 * 60 * 30;
+  } else {
+    newPlan._endTime = newPlan.endTime;
   }
 
   return newPlan;


### PR DESCRIPTION
- Closes #166
- Closes #169

## ✨ **구현 기능 명세**

### React-Query 코드 컨벤션 통일

* React-Query에서 사용하는 Hook의 이름을 `plan`과 `category` 모두 동시에 사용하도록 변경했습니다.
* React-Query에서 사용하는 Key를 enum으로 `constant`에 가지고 있도록 변경했습니다.

### Timetable 일정 버그 수정

Tiemtable의 일정을 새로 생성할 때 안보이던 버그를 수정했습니다.
(#169 참조)

## 😭 **어려웠던 점**

원래는 React-Query의 월간 일정, 카테고리 등을 number 배열로 caching data 관리하려 했습니다.
다만, 저장 & 참조 시 이 number 배열을 통해 다른 데이터를 보여주기 위한 작업이 가독성을 헤쳤으며 또한 그 이점이 제대로 보이지 않았기 때문에 이번 리팩토링에는 적용하지 않았습니다.