### PR TITLE
카테고리 삭제 실패시 toast 메시지 올바르게 뜨도록 해결

### DIFF
--- a/src/components/modal/category/index.tsx
+++ b/src/components/modal/category/index.tsx
@@ -41,9 +41,9 @@ const CategoryModalViewer: React.FC<object> = () => {
 
   const originalCategory = useCategoryQuery({ id });
   const { data: categoryData } = useCategoryQuery();
-  const { mutate: createCategory } = useCreateCategory();
-  const { mutate: updateCategory } = useUpdateCategory();
-  const { mutate: deleteCategory } = useDeleteCategory();
+  const { mutateAsync: createCategory } = useCreateCategory();
+  const { mutateAsync: updateCategory } = useUpdateCategory();
+  const { mutateAsync: deleteCategory } = useDeleteCategory();
 
   const [newName, setNewName] = useState<string>(
     originalCategory?.name ?? DEFAULT_NAME,
@@ -81,16 +81,16 @@ const CategoryModalViewer: React.FC<object> = () => {
     return true;
   };
 
-  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!checkCategoryValid()) return;
 
     try {
       const newData = { name: newName, color: selectedColor };
       if (type === 'create') {
-        createCategory(newData);
+        await createCategory(newData);
       } else if (isEdit && id !== null) {
-        updateCategory({ id, ...newData });
+        await updateCategory({ id, ...newData });
       }
       closeCategoryModal();
       toast(
@@ -105,14 +105,14 @@ const CategoryModalViewer: React.FC<object> = () => {
     }
   };
 
-  const onDelete: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+  const onDelete: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
     // *: prevent from submit
     e.preventDefault();
     // *: if editing or no category info, don't execute
     if (!isEdit || !originalCategory) return;
 
     try {
-      deleteCategory(originalCategory);
+      await deleteCategory(originalCategory);
       closeCategoryModal();
       toast(
         <div>


### PR DESCRIPTION
- Closes #175 

## ✨ **구현 기능 명세**

카테고리 삭제 실피시 toast 메시지가 `삭제에 실패했습니다` 가 아닌 `삭제에 성공했습니다`가 뜨는 오류가 있었습니다. 이 버그를 해결했습니다.

## 🎁 **주목할 점**

### mutate와 mutateAsync의 차이

`mutate` 함수는 Promise가 아닙니다. 그래서 성공시, 실패시에 호출되어야 하는 함수를 콜백함수로 넘겨주어야 합니다.

```ts
mutate(id, {
   onSuccess: () => { ... },
   onError: () => { ... },
   onSettled: () => { ... },
});
```

`mutateAsync` 함수는 Promise입니다. 그래서 async/await 문법을 사용해서 사용하면 됩니다.

```ts
async () => {
    try {
       await mutateAsync(id);
       onSuccess();
   } catch (e) {
       onError();
   } finally {
       onSettled();
   }
}
```

## 🌄 **스크린샷**

![toast](https://github.com/JiPyoTak/plandar-client/assets/32933980/a673a8b0-da22-4221-abf0-485e66ccfb38)
