### PR TITLE
월 달력에서 일정 렌더링시 날짜차이가 날 경우 종일 일정으로 렌더링하도록 변경

### DIFF
--- a/src/components/home/main/timetable/view/TimetableAllDay.tsx
+++ b/src/components/home/main/timetable/view/TimetableAllDay.tsx
@@ -47,7 +47,7 @@ const TimetableAllDay: React.FC<TProps> = ({
       new DaysPlanManager({
         plans: [
           ...allDayPlans.filter((plan) => plan.id !== focusedPlan?.id),
-          ...(focusedPlan ? [focusedPlan] : []),
+          ...(focusedPlan?.isAllDay ? [focusedPlan] : []),
         ],
         start: dateMoments[0],
         end: dateMoments[dateMoments.length - 1],

--- a/src/components/home/sidebar/SidebarIcons.tsx
+++ b/src/components/home/sidebar/SidebarIcons.tsx
@@ -66,6 +66,8 @@ const SidebarIcons = () => {
 };
 
 const Container = styled.div`
+  position: relative;
+
   height: 100%;
   max-height: 100vh;
 
@@ -98,6 +100,8 @@ const Menu = styled.div`
 `;
 
 const Footer = styled(Header)`
+  position: absolute;
+  bottom: 0;
   height: ${MENU_PROFILE_HEIGHT};
   position: absolute;
   bottom: 0;

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -57,6 +57,7 @@ const Container = styled.div`
 const ToastWrapper = styled(Container)`
   bottom: 0;
   left: 50%;
+  transform: translateX(-50%);
 
   transition: all 300ms;
 `;

--- a/src/core/plan/DaysPlanManager.ts
+++ b/src/core/plan/DaysPlanManager.ts
@@ -3,7 +3,7 @@ import moment, { Moment } from 'moment';
 import Plan from './Plan';
 import PlanManager from './PlanManager';
 import type { IViewInfo } from './PlanManager';
-import { divideTimePlans } from '@/utils/plan/divideTimePlans';
+import { divideTimePlansByDate } from '@/utils/plan/divideTimePlans';
 
 export interface IDayViewInfo extends IViewInfo {
   id: number;
@@ -38,7 +38,7 @@ class DaysPlanManager extends PlanManager<IDayViewInfo> {
         !currentStart.isAfter(endMoment) && !currentEnd.isBefore(startMoment)
       );
     });
-    const { timePlans, allDayPlans } = divideTimePlans(filteredPlans);
+    const { timePlans, allDayPlans } = divideTimePlansByDate(filteredPlans);
 
     super(allDayPlans);
     this.startDate = currentStart;
@@ -62,7 +62,8 @@ class DaysPlanManager extends PlanManager<IDayViewInfo> {
         : currentEnd.clone(),
     ];
 
-    const term = Math.abs(viewStart.diff(viewEnd, 'd')) + 1;
+    const term =
+      viewEnd.clone().endOf('d').diff(viewStart.clone().startOf('d'), 'd') + 1;
 
     return {
       id: plan.id,

--- a/src/hooks/usePlanPreviewEvent.ts
+++ b/src/hooks/usePlanPreviewEvent.ts
@@ -28,14 +28,15 @@ const usePlanPreviewEvent = () => {
       shallow,
     );
 
-  const { selectedPlanId, setSelectedPlan } = useSelectedPlanState(
-    ({ selectedPlan, setSelectedPlan, clearSelectedPlan }) => ({
-      selectedPlanId: selectedPlan?.id,
-      setSelectedPlan,
-      clearSelectedPlan,
-    }),
-    shallow,
-  );
+  const { selectedPlanId, setSelectedPlan, clearSelectedPlan } =
+    useSelectedPlanState(
+      ({ selectedPlan, setSelectedPlan, clearSelectedPlan }) => ({
+        selectedPlanId: selectedPlan?.id,
+        setSelectedPlan,
+        clearSelectedPlan,
+      }),
+      shallow,
+    );
 
   const [debounceToSetHoveredPlan, clearDebounce] = useDebounce(
     setHoveredPlan,
@@ -65,6 +66,7 @@ const usePlanPreviewEvent = () => {
 
   const onMouseDown = (plan: Plan) => {
     clearHoveredPlan();
+    clearSelectedPlan();
     moveDragPlan(plan);
   };
 

--- a/src/utils/plan/divideTimePlans.ts
+++ b/src/utils/plan/divideTimePlans.ts
@@ -16,4 +16,25 @@ const divideTimePlans = (plans: IPlan[]) => {
   );
 };
 
-export { divideTimePlans };
+const divideTimePlansByDate = (plans: Plan[]) => {
+  return plans.reduce(
+    ({ timePlans, allDayPlans }, planData) => {
+      const { startMoment, endMoment } = planData;
+      const isSameDate = startMoment.isSame(endMoment, 'd');
+
+      if (isSameDate) {
+        timePlans.push(planData);
+      } else {
+        allDayPlans.push(planData);
+      }
+
+      return { timePlans, allDayPlans };
+    },
+    { timePlans: [], allDayPlans: [] } as {
+      timePlans: Plan[];
+      allDayPlans: Plan[];
+    },
+  );
+};
+
+export { divideTimePlans, divideTimePlansByDate };


### PR DESCRIPTION
- Closes #174

## ✨ **구현 기능 명세**
- 날짜 차이가 나는 일정을 월 달력에서는 종일 일정으로, 주/일 달력에서는 시간 일정으로 렌더링 하도록 변경합니다.

## 🎁 **주목할 점**

이전 일정을 렌더링 하는 방식은 `isAllDay`나 `isTimePlan`으로 검사하여 렌더링 여부를 결정하고 있습니다.

하지만 월 달력에 경우 날짜차이가 나는 일정이어도 종일 일정이 아니라면 시간 일정을 렌더링 하는 방식을 사용하고 있습니다.

이를 날짜차이를 계산하여 2일 이상에 걸쳐 생성된 일정일 경우 종일 일정으로 렌더링 하도록 변경합니다.

## 😭 **어려웠던 점**

`DaysPlanManager`는 월 달력과 주 달력 모두에서 사용됩니다.

초기 주달력에서 렌더링 될때는 필터링된 일정이기에 문제가 없지만 특정 일정이 선택되었을 때는 따로 검사하는 로직이 존재하지 않았습니다.

이를 위해 선택된 일정이 어떤 일정인지 한번더 검사하는 로직을 추가했습니다.

|![화면 기록 2023-09-15 오후 3 03 38](https://github.com/JiPyoTak/plandar-client/assets/60173534/c85e54b8-39e7-49c5-80d1-e743b90a9346)|![화면 기록 2023-09-15 오후 3 05 31](https://github.com/JiPyoTak/plandar-client/assets/60173534/672dde87-d979-4351-878c-ff3075f00b7f)|
|:---:|:---:|
|수정 이전|수정 이후|


## 🌄 **스크린샷**
|<img width="625" alt="image" src="https://github.com/JiPyoTak/plandar-client/assets/60173534/6fb389c2-c60e-4a7a-9853-26e5a434f06d">|<img width="625" alt="image" src="https://github.com/JiPyoTak/plandar-client/assets/60173534/434afab8-28f3-4841-bbb8-584dbaf134a2">|
|:---:|:---:|
|수정 이전|수정 이후|


