### PR TITLE
Timetable 스크롤, Tag Skeleton View 버그 수정 및 날짜 및 시간 선택 스타일 변경

### DIFF
--- a/src/components/home/main/timetable/TimetableScroll.tsx
+++ b/src/components/home/main/timetable/TimetableScroll.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren, createContext, useContext } from 'react';
 
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import useTimetableScroll, {
@@ -8,6 +9,7 @@ import useTimetableScroll, {
 import useSelectedPlanState from '@/stores/plan/selectedPlan';
 import { FONT_BOLD_8 } from '@/styles/font';
 import {
+  TIMETABLE_HIDE_SCROLL_STYLE,
   TIMETABLE_SCROLL_STYLE,
   TIMETABLE_SCROLL_WIDTH,
 } from '@/styles/timetable';
@@ -44,6 +46,7 @@ const HorizontalScroll: React.FC<THorizontalScrollProps> = ({
   const id = scrollId || '';
   const isReceiver = !showScroll && scrollId;
   const { signTag, onMoveHorizontalScroll } = useContext(Context) || {};
+  const theme = useTheme();
 
   const scrollCallbackRef: React.LegacyRef<HTMLDivElement> = (element) => {
     if (isReceiver && signTag) {
@@ -57,7 +60,11 @@ const HorizontalScroll: React.FC<THorizontalScrollProps> = ({
     <FlexibleContainer className={className}>
       <FixedDiv>{fixedComponent}</FixedDiv>
       <HorizontalScrollDiv
-        css={{ overflowX: showScroll ? 'auto' : 'hidden' }}
+        css={
+          isReceiver
+            ? TIMETABLE_HIDE_SCROLL_STYLE
+            : TIMETABLE_SCROLL_STYLE({ theme })
+        }
         ref={scrollCallbackRef}
         onScroll={onMoveHorizontalScroll}
       >
@@ -110,10 +117,9 @@ const FixedDiv = styled.div`
 `;
 
 const HorizontalScrollDiv = styled.div`
-  ${TIMETABLE_SCROLL_STYLE}
-
   flex: 1 0 0;
 
+  overflow-x: auto;
   overflow-y: hidden;
 `;
 

--- a/src/components/home/main/timetable/TimetableScroll.tsx
+++ b/src/components/home/main/timetable/TimetableScroll.tsx
@@ -43,13 +43,13 @@ const HorizontalScroll: React.FC<THorizontalScrollProps> = ({
   scrollId,
   showScroll,
 }) => {
+  const theme = useTheme();
   const id = scrollId || '';
   const isReceiver = !showScroll && scrollId;
   const { signTag, onMoveHorizontalScroll } = useContext(Context) || {};
-  const theme = useTheme();
 
   const scrollCallbackRef: React.LegacyRef<HTMLDivElement> = (element) => {
-    if (isReceiver && signTag) {
+    if (signTag) {
       signTag({ id, ref: element });
     }
   };

--- a/src/components/home/main/timetable/index.tsx
+++ b/src/components/home/main/timetable/index.tsx
@@ -50,6 +50,7 @@ const VerticalScrollController = ({ cellLength }: { cellLength: number }) => {
     <TimetableScroll.Horizontal
       css={{ marginRight: TIMETABLE_SCROLL_WIDTH }}
       showScroll={showScroll}
+      scrollId="controller"
     >
       <VerticalEmptyCell cellLength={cellLength} />
     </TimetableScroll.Horizontal>

--- a/src/components/home/sidebar/content/classifier/TagClassifier.tsx
+++ b/src/components/home/sidebar/content/classifier/TagClassifier.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useEffect } from 'react';
 
 import ClassifierGuide from '@/components/common/classifier/ClassifierGuide';
 import ClassifierItem from '@/components/common/classifier/ClassifierItem';
@@ -11,6 +11,13 @@ import useTagClassifierState from '@/stores/classifier/tag';
 const TagClassifier: React.FC = () => {
   const { hiddenTags, toggleTagShow } = useTagClassifierState();
   const { data: plans, isLoading: isLoadingPlan } = useRangedPlans();
+  const isFirstRef = useRef(true);
+
+  useEffect(() => {
+    if (!isLoadingPlan) {
+      isFirstRef.current = false;
+    }
+  }, [isLoadingPlan]);
 
   const tags = useMemo(() => {
     const tagNameSet = new Set<string>();
@@ -24,20 +31,19 @@ const TagClassifier: React.FC = () => {
     return [...tagNameSet].sort();
   }, [plans]);
 
+  const isEmpty = isFirstRef.current && isLoadingPlan;
+
   return (
     <div css={{ padding: '1rem 0' }}>
       <Dropdown>
         <Dropdown.Controller>
           <ClassifierTitle title={'태그'} />
         </Dropdown.Controller>
-        <ClassifierGuide
-          icon={TagIcon}
-          isShow={!tags?.length && !isLoadingPlan}
-        >
+        <ClassifierGuide icon={TagIcon} isShow={!tags?.length && !isEmpty}>
           <span>일정에 태그를 추가해서</span>
           <span>일정을 분류해보세요!</span>
         </ClassifierGuide>
-        {isLoadingPlan &&
+        {isEmpty &&
           [...Array(2)].map((_, index) => (
             <ClassifierItem.Skeleton key={index} />
           ))}

--- a/src/components/modal/plan/create/plan-date/DatePicker.tsx
+++ b/src/components/modal/plan/create/plan-date/DatePicker.tsx
@@ -101,7 +101,6 @@ const CalendarContainer = styled.div`
 `;
 
 const CalendarDateButton = styled.button<{ calendarOpened: boolean }>`
-  width: 75px;
   padding: 3px 5px;
   border-radius: 5px;
   border: 2px solid

--- a/src/components/modal/plan/create/plan-date/DatePicker.tsx
+++ b/src/components/modal/plan/create/plan-date/DatePicker.tsx
@@ -58,7 +58,10 @@ const DatePicker = ({ date, onChangeDate, onCalendarClose }: Props) => {
 
   return (
     <div>
-      <CalendarDateButton onClick={onClickDateButton}>
+      <CalendarDateButton
+        calendarOpened={calendarOpened}
+        onClick={onClickDateButton}
+      >
         {getDateString(date.toDate())}
       </CalendarDateButton>
       <ModalBackground isOpen={calendarOpened} onClose={onCloseHandler} />
@@ -97,9 +100,12 @@ const CalendarContainer = styled.div`
   box-shadow: rgb(0 0 0 / 15%) 0px 4px 16px 0px;
 `;
 
-const CalendarDateButton = styled.button`
+const CalendarDateButton = styled.button<{ calendarOpened: boolean }>`
+  width: 75px;
   padding: 3px 5px;
   border-radius: 5px;
+  border: 2px solid
+    ${({ calendarOpened }) => (calendarOpened ? '#1053C0' : 'transparent')};
   background-color: ${({ theme }) => theme.white};
   ${FONT_REGULAR_4}
 

--- a/src/components/modal/plan/create/plan-date/TimeInput.tsx
+++ b/src/components/modal/plan/create/plan-date/TimeInput.tsx
@@ -106,23 +106,21 @@ const TimeInput = ({ setTime, time }: Props) => {
 
 const Input = styled.input<{ invalid?: boolean }>`
   width: 80px;
-
-  margin: 0 2px;
-  border-radius: 5px;
+  padding: 3px 5px;
   ${FONT_REGULAR_4}
 
   text-align: center;
-  border: none;
+  border-radius: 5px;
+  border: 2px solid transparent;
   outline: none;
 
   &:hover {
     background-color: ${({ theme }) => theme.background3};
   }
   &:focus {
-    background-color: ${({ theme }) => theme.background3};
-    border-radius: 5px 5px 0 0;
-    border-bottom: 2px solid
-      ${({ invalid, theme }) => (invalid ? theme.red : theme.primary)};
+    background-color: ${({ theme }) => theme.background1};
+    border: 2px solid
+      ${({ invalid, theme }) => (invalid ? theme.red : '#1053C0')};
   }
 `;
 

--- a/src/styles/scroll.ts
+++ b/src/styles/scroll.ts
@@ -6,12 +6,24 @@ const BOX_SCROLL_Y = ({ theme }: { theme: Theme }) => css`
   }
 
   &::-webkit-scrollbar-thumb {
-    border: 4px solid transparent;
-
-    border-radius: 8px;
+    height: 50px;
+    border: 2px solid transparent;
+    border-top: none;
+    border-bottom: none;
+    border-radius: 4px;
 
     background-clip: padding-box;
     background-color: ${theme.border2};
+  }
+
+  &::-webkit-scrollbar-track-piece:end {
+    background-color: transparent;
+    margin-bottom: 6px;
+  }
+
+  &::-webkit-scrollbar-track-piece:start {
+    background-color: transparent;
+    margin-top: 6px;
   }
 `;
 

--- a/src/styles/timetable.ts
+++ b/src/styles/timetable.ts
@@ -15,6 +15,15 @@ const TIMETABLE_SCROLL_STYLE = ({ theme }: { theme: Theme }) => css`
   }
 `;
 
+const TIMETABLE_HIDE_SCROLL_STYLE = css`
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    display: none;
+  }
+`;
+
 const TIMETABLE_CELL_MIN_WIDTH = '4.875rem';
 const TIMETABLE_CELL_HEIGHT = '1rem';
 
@@ -30,6 +39,7 @@ const TIMETABLE_Z_INDEX = {
 export {
   TIMETABLE_SCROLL_WIDTH,
   TIMETABLE_SCROLL_STYLE,
+  TIMETABLE_HIDE_SCROLL_STYLE,
   TIMETABLE_CELL_MIN_WIDTH,
   TIMETABLE_CELL_HEIGHT,
   TIMETABLE_ALL_DAY_VERTICAL_PADDING,


### PR DESCRIPTION
- Closes #173
- Closes #176 
- Closes #179 

## ✨ **구현 기능 명세**

### Timetable 가로 스크롤을 터치 패드에서 가능하도록 변경

이전의 Timetable 가로 스크롤은 터치 패드에서 불가능했습니다.
`overflow-x` 속성을 hidden으로 변경한 뒤 JS로 스크롤 위치를 변경하여 스크롤을 구현했기 때문에
hidden 속성이 있는 곳은 event 발생이 이루어지지 않았기 때문입니다.

이를 `overflow-x: auto`로 모든 가로 스크롤 이벤트가 발생할 수 있도록 변경하고
스크롤을 보여주면 안되는 곳에 `display: none` 속성을 주어 스크롤을 숨겼습니다.

### Tag Classifier Skeleton View를 처음에만 보여주도록 설정

Tag Classifier의 아이템들은 일정을 네트워크로 불러올 때 Skeleton View로 보여줄 수 있도록 합니다.
이때 달력에서 달을 지속적으로 넘길때 오히려 UX를 해치는 현상이 발생했습니다.

![화면 기록 2023-09-15 오후 3 09 30](https://github.com/JiPyoTak/plandar-client/assets/55688122/1499aae2-9090-421a-bb34-0a6ceba5e6a8)

맨 처음 페이지 로딩이 끝난 뒤에는 Skeleton View를 보여주지 않도록 설정해 이를 해결했습니다.

### 일정 시간 선택 스타일 변경

일정 날짜와 시간 선택 시 좀 더 직관적으로 알 수 있도록 스타일을 변경했습니다.

|before|after|
|:---:|:---:|
|<img alt="before time" src="https://github.com/JiPyoTak/plandar-client/assets/55688122/ab807dfa-412b-44dc-9ba2-2483f2160b22" width="200"/>|<img alt="after time" src="https://github.com/JiPyoTak/plandar-client/assets/55688122/33115047-d15c-4ba2-8df6-30e8b746129d" width="200"/>|

|before|after|
|:---:|:---:|
|<img alt="before day" src="https://github.com/JiPyoTak/plandar-client/assets/55688122/a048802e-8eee-4005-848a-448903cae3f6" width="200"/>|<img alt="after day" src="https://github.com/JiPyoTak/plandar-client/assets/55688122/e036e2a3-71f0-4bfa-89ae-ebab3d6a8589" width="200"/>|
